### PR TITLE
feat(pods): add pull policy to containers config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:1.12 as build-deps
 WORKDIR /hatchery
 ENV GOPATH=/hatchery
 
+RUN go get k8s.io/klog && cd $GOPATH/src/k8s.io/klog && git checkout v0.4.0
+
 RUN go get -tags k8s.io/client-go/kubernetes \
     k8s.io/apimachinery/pkg/apis/meta/v1 \
     k8s.io/api/core/v1 \

--- a/src/handlers/config.go
+++ b/src/handlers/config.go
@@ -13,6 +13,7 @@ type Container struct {
 	CPULimit           string            `json:"cpu-limit"`
 	MemoryLimit        string            `json:"memory-limit"`
 	Image              string            `json:"image"`
+	PullPolicy         string            `json:"pull_policy"`
 	Env                map[string]string `json:"env"`
 	TargetPort         int32             `json:"target-port"`
 	Args               []string          `json:"args"`

--- a/src/handlers/pods.go
+++ b/src/handlers/pods.go
@@ -262,7 +262,19 @@ func createK8sPod(hash string, accessToken string, userName string) error {
 				MountPath:        containerSettings.UserVolumeLocation,
 				Name:             "user-data",
 		})
-		
+
+	}
+
+	var pullPolicy k8sv1.PullPolicy
+	switch containerSettings.PullPolicy {
+	case "IfNotPresent":
+		pullPolicy = k8sv1.PullPolicy(k8sv1.PullIfNotPresent)
+	case "Always":
+		pullPolicy = k8sv1.PullPolicy(k8sv1.Always)
+	case "Never":
+		pullPolicy = k8sv1.PullPolicy(k8sv1.Never)
+	default:
+		pullPolicy = k8sv1.PullPolicy(k8sv1.PullIfNotPresent)
 	}
 
 	pod := &k8sv1.Pod{
@@ -282,7 +294,7 @@ func createK8sPod(hash string, accessToken string, userName string) error {
 					SecurityContext: &k8sv1.SecurityContext{
 						Privileged: &falseVal,
 					},
-					ImagePullPolicy: k8sv1.PullPolicy(k8sv1.PullIfNotPresent),
+					ImagePullPolicy: pullPolicy,
 					Env:             envVars,
 					Command:         containerSettings.Command,
 					Args:            containerSettings.Args,

--- a/src/handlers/pods.go
+++ b/src/handlers/pods.go
@@ -270,9 +270,9 @@ func createK8sPod(hash string, accessToken string, userName string) error {
 	case "IfNotPresent":
 		pullPolicy = k8sv1.PullPolicy(k8sv1.PullIfNotPresent)
 	case "Always":
-		pullPolicy = k8sv1.PullPolicy(k8sv1.Always)
+		pullPolicy = k8sv1.PullPolicy(k8sv1.PullAlways)
 	case "Never":
-		pullPolicy = k8sv1.PullPolicy(k8sv1.Never)
+		pullPolicy = k8sv1.PullPolicy(k8sv1.PullNever)
 	default:
 		pullPolicy = k8sv1.PullPolicy(k8sv1.PullIfNotPresent)
 	}


### PR DESCRIPTION
<!-- Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review. -->

### New Features
- Add support to specifying the Pull Request Policy for containers, available options: `Always`, `IfNotPresent` and `Never`. For backward compatibility, missing `pull_policy` will use default, `IfNotPresent` policy.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- New `pull_policy` option is available for `hatchery.containers` entries, eg:

```
{
    "target-port": 8787,
    "cpu-limit": "1.0",
    "memory-limit": "512Mi",
    "pull_policy": "Always",
    "name": "R Studio",
    "image": "heliumdatastage/rstudio-server:1",
    "env": {
        "DISABLE_AUTH": "true"
    },
    "args": [],
    "path-rewrite": "/",
    "use-tls": "false",
    "ready-probe": "/"
}
```