### PR TITLE
Update hatcheryOverview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Hatchery creates Kubernetes Pods for workspace services. Workspace services must
 See [this bLog](https://www.divio.com/blog/documentation/) for an introduction to the different types of documentation (explanation, how-to, tutorial, reference).
 
 ### Explanation
-* [hatchery overview](doc/explain/hatcheryOverview.md)
+* [hatchery overview](doc/explanation/hatcheryOverview.md)
 * [api](doc/explain/hatcheryApi.md)
 
 ### How-to


### PR DESCRIPTION
Correct path to hatcheryOverview.md.

### Improvements

The link to hatcheryOverview.md was broken as the path to the file in the docs directory expected the sub directory explain rather than the correct sub directory explanation. Updated link path to resolve to the correct location.