### PR TITLE
fix(may-release): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as build-deps
+FROM quay.io/cdis/golang:1.14 as build-deps
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     vim


### PR DESCRIPTION
Address this issue:

> Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit