### PR TITLE
fix: hash

### DIFF
--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -116,8 +116,9 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 		}
 	}
 	for _, container := range data.Config.Containers {
-		toHash := container.Name + "-" + container.Image + "-" + container.CPULimit + "-" + container.MemoryLimit
-		hash := fmt.Sprintf("%x", md5.Sum([]byte(toHash)))
+		jsonBytes, _ := json.Marshal(container)
+		// toHash := container.Name + "-" + container.Image + "-" + container.CPULimit + "-" + container.MemoryLimit
+		hash := fmt.Sprintf("%x", md5.Sum([]byte(jsonBytes)))
 		data.ContainersMap[hash] = container
 	}
 	return data, nil

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -117,7 +117,6 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 	}
 	for _, container := range data.Config.Containers {
 		jsonBytes, _ := json.Marshal(container)
-		// toHash := container.Name + "-" + container.Image + "-" + container.CPULimit + "-" + container.MemoryLimit
 		hash := fmt.Sprintf("%x", md5.Sum([]byte(jsonBytes)))
 		data.ContainersMap[hash] = container
 	}


### PR DESCRIPTION
Let Hatchery calculate contaioner option hash base on the entire JSON config object, rather than just the combination of `name + image + cpu + mem`

So that these 2 containers configs are not being clashed into one

```
  {
      "target-port": 8888,
      "cpu-limit": "1.0",
      "memory-limit": "512Mi",
      "name": "Same workspace option name",
      "image": "quay.io/occ_data/jupyternotebook:1.7.2"
    },
  {
      "target-port": 5800,
      "cpu-limit": "1.0",
      "memory-limit": "512Mi",
      "name": "Same workspace option name",
      "image": "quay.io/occ_data/jupyternotebook:1.7.2",
      "friends": [
        {
          "name": "firefox",
          "image": "quay.io/cdis/docker-firefox:master",
          }
      ] 
 }
```

Deployed in https://mingfei.planx-pla.net/workspace


### Bug Fixes
- fix container option hash calculation to avoid clashes
