### PR TITLE
PXP-8453 Feat/eks api key

### DIFF
--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -193,9 +193,9 @@ func MakeARequestWithContext(ctx context.Context, method string, apiEndpoint str
 
 func getFenceURL() string {
 	fenceURL := "http://fence-service/"
-	_, ok := os.LookupEnv("FENCE_URL")
+	_, ok := os.LookupEnv("HOSTNAME")
 	if ok {
-		fenceURL = os.Getenv("FENCE_URL")
+		fenceURL = "https://" + os.Getenv("HOSTNAME") + "/user"
 	}
 	if !strings.HasSuffix(fenceURL, "/") {
 		fenceURL += "/"
@@ -221,11 +221,12 @@ func getAPIKeyWithContext(ctx context.Context, accessToken string) (apiKey *APIK
 	}
 	defer resp.Body.Close()
 
-	err = json.NewDecoder(resp.Body).Decode(apiKey)
+	fenceApiKeyResponse := new(APIKeyStruct)
+	err = json.NewDecoder(resp.Body).Decode(fenceApiKeyResponse)
 	if err != nil {
 		return nil, errors.New("Unable to decode API key response: " + err.Error())
 	}
-	return apiKey, nil
+	return fenceApiKeyResponse, nil
 }
 
 func deleteAPIKeyWithContext(ctx context.Context, accessToken string, apiKeyID string) error {

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -176,7 +176,11 @@ func MakeARequestWithContext(ctx context.Context, method string, apiEndpoint str
 	client := &http.Client{Timeout: 10 * time.Second}
 	var req *http.Request
 	var err error
-	req, err = http.NewRequestWithContext(ctx, method, apiEndpoint, body)
+	if body == nil {
+		req, err = http.NewRequestWithContext(ctx, method, apiEndpoint, nil)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, apiEndpoint, body)
+	}
 
 	if err != nil {
 		return nil, errors.New("Error occurred during generating HTTP request: " + err.Error())

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -176,7 +176,7 @@ func MakeARequestWithContext(ctx context.Context, method string, apiEndpoint str
 	client := &http.Client{Timeout: 10 * time.Second}
 	var req *http.Request
 	var err error
-	req, err = http.NewRequest(method, apiEndpoint, body)
+	req, err = http.NewRequestWithContext(ctx, method, apiEndpoint, body)
 
 	if err != nil {
 		return nil, errors.New("Error occurred during generating HTTP request: " + err.Error())
@@ -209,7 +209,7 @@ func getAPIKeyWithContext(ctx context.Context, accessToken string) (apiKey *APIK
 	}
 
 	fenceAPIKeyURL := getFenceURL() + "credentials/api/"
-	body := bytes.NewBufferString("{\"scope\": \"[\"data\", \"user\"]\"}")
+	body := bytes.NewBufferString("{\"scope\": [\"data\", \"user\"]}")
 
 	resp, err := MakeARequestWithContext(ctx, "POST", fenceAPIKeyURL, accessToken, "application/json", nil, body)
 	if err != nil {

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -272,6 +272,8 @@ func deleteK8sPod(ctx context.Context, accessToken string, userName string) erro
 		err := deleteAPIKeyWithContext(ctx, accessToken, mountedAPIKeyID)
 		if err != nil {
 			fmt.Printf("Error occurred when deleting API Key with ID %s for user %s: %s\n", mountedAPIKeyID, userName, err.Error())
+		} else {
+			fmt.Printf("API Key with ID %s for user %s has been deleted\n", mountedAPIKeyID, userName)
 		}
 	}
 

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -345,6 +346,30 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 	for _, value := range extraVars {
 		sidecarEnvVars = append(sidecarEnvVars, value)
 		envVars = append(envVars, value)
+	}
+	sidecarEnvVarsCopy := sidecarEnvVars[:0]
+	for i, value := range sidecarEnvVarsCopy {
+		if value.Name == "HOSTNAME" {
+			break
+		}
+		if i == len(sidecarEnvVarsCopy)-1 {
+			sidecarEnvVars = append(sidecarEnvVars, k8sv1.EnvVar{
+				Name:  "HOSTNAME",
+				Value: os.Getenv("HOSTNAME"),
+			})
+		}
+	}
+	envVarsCopy := envVars[:0]
+	for i, value := range envVarsCopy {
+		if value.Name == "HOSTNAME" {
+			break
+		}
+		if i == len(envVarsCopy)-1 {
+			envVars = append(envVars, k8sv1.EnvVar{
+				Name:  "HOSTNAME",
+				Value: os.Getenv("HOSTNAME"),
+			})
+		}
 	}
 
 	//hatchConfig.Logger.Printf("sidecar configured")
@@ -745,7 +770,7 @@ func createExternalK8sPod(ctx context.Context, hash string, accessToken string, 
 
 	extraVars = append(extraVars, k8sv1.EnvVar{
 		Name:  "WTS_OVERRIDE_URL",
-		Value: "https://" + Config.Config.Sidecar.Env["HOSTNAME"] + "/wts",
+		Value: "https://" + os.Getenv("HOSTNAME") + "/wts",
 	})
 	extraVars = append(extraVars, k8sv1.EnvVar{
 		Name:  "API_KEY",

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -636,7 +636,22 @@ func createK8sPod(ctx context.Context, hash string, accessToken string, userName
 func createLocalK8sPod(ctx context.Context, hash string, accessToken string, userName string) error {
 	hatchApp := Config.ContainersMap[hash]
 
+	apiKey, err := getAPIKeyWithContext(ctx, accessToken)
+	if err != nil {
+		Config.Logger.Printf("Failed to get API key for user %v, Error: %v", userName, err)
+		return err
+	}
+	Config.Logger.Printf("Created API key for user %v, key ID: %v", userName, apiKey.KeyID)
+
 	var extraVars []k8sv1.EnvVar
+	extraVars = append(extraVars, k8sv1.EnvVar{
+		Name:  "API_KEY",
+		Value: apiKey.APIKey,
+	})
+	extraVars = append(extraVars, k8sv1.EnvVar{
+		Name:  "API_KEY_ID",
+		Value: apiKey.KeyID,
+	})
 	pod, err := buildPod(Config, &hatchApp, userName, extraVars)
 	if err != nil {
 		Config.Logger.Printf("Failed to configure pod for launch for user %v, Error: %v", userName, err)

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -349,7 +349,9 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 		sidecarEnvVars = append(sidecarEnvVars, value)
 		envVars = append(envVars, value)
 	}
+	// scan if sidecarEnvVars has HOSTNAME, and add it if not
 	sidecarEnvVarsCopy := sidecarEnvVars[:0]
+	// this is the best we can do with golang
 	for i, value := range sidecarEnvVarsCopy {
 		if value.Name == "HOSTNAME" {
 			break
@@ -361,6 +363,7 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 			})
 		}
 	}
+	// do the same thing for envVars
 	envVarsCopy := envVars[:0]
 	for i, value := range envVarsCopy {
 		if value.Name == "HOSTNAME" {

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -636,22 +636,7 @@ func createK8sPod(ctx context.Context, hash string, accessToken string, userName
 func createLocalK8sPod(ctx context.Context, hash string, accessToken string, userName string) error {
 	hatchApp := Config.ContainersMap[hash]
 
-	apiKey, err := getAPIKeyWithContext(ctx, accessToken)
-	if err != nil {
-		Config.Logger.Printf("Failed to get API key for user %v, Error: %v", userName, err)
-		return err
-	}
-	Config.Logger.Printf("Created API key for user %v, key ID: %v", userName, apiKey.KeyID)
-
 	var extraVars []k8sv1.EnvVar
-	extraVars = append(extraVars, k8sv1.EnvVar{
-		Name:  "API_KEY",
-		Value: apiKey.APIKey,
-	})
-	extraVars = append(extraVars, k8sv1.EnvVar{
-		Name:  "API_KEY_ID",
-		Value: apiKey.KeyID,
-	})
 	pod, err := buildPod(Config, &hatchApp, userName, extraVars)
 	if err != nil {
 		Config.Logger.Printf("Failed to configure pod for launch for user %v, Error: %v", userName, err)

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -783,10 +783,11 @@ func createExternalK8sPod(ctx context.Context, hash string, accessToken string, 
 		Name:  "API_KEY_ID",
 		Value: apiKey.KeyID,
 	})
-	// extraVars = append(extraVars, k8sv1.EnvVar{
-	// 	Name:  "ACCESS_TOKEN",
-	// 	Value: accessToken,
-	// })
+	// TODO: still mounting access token for now, remove this when fully switched to use API key
+	extraVars = append(extraVars, k8sv1.EnvVar{
+		Name:  "ACCESS_TOKEN",
+		Value: accessToken,
+	})
 
 	pod, err := buildPod(Config, &hatchApp, userName, extraVars)
 	if err != nil {

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -268,10 +268,10 @@ func deleteK8sPod(ctx context.Context, accessToken string, userName string) erro
 		}
 	}
 	if mountedAPIKeyID != "" {
-		fmt.Printf("Found mounted API key. Attempting to delete API Key for user %s\n", userName)
+		fmt.Printf("Found mounted API key. Attempting to delete API Key with ID %s for user %s\n", mountedAPIKeyID, userName)
 		err := deleteAPIKeyWithContext(ctx, accessToken, mountedAPIKeyID)
 		if err != nil {
-			fmt.Printf("Error occurred when deleting API Key for user %s\n", userName)
+			fmt.Printf("Error occurred when deleting API Key with ID %s for user %s: %s\n", mountedAPIKeyID, userName, err.Error())
 		}
 	}
 
@@ -753,6 +753,7 @@ func createExternalK8sPod(ctx context.Context, hash string, accessToken string, 
 		Config.Logger.Printf("Failed to get API key for user %v, Error: %v", userName, err)
 		return err
 	}
+	Config.Logger.Printf("Created API key for user %v, key ID: %v", userName, apiKey.KeyID)
 
 	// Check if NS exists in external cluster, if not create it.
 	ns, err := podClient.Namespaces().Get(ctx, Config.Config.UserNamespace, metav1.GetOptions{})


### PR DESCRIPTION
Jira Ticket: [PXP-8453](https://ctds-planx.atlassian.net/browse/PXP-8453)

For workspace pod in external EKS cluster (decoupled workspace)
- When launching, generate an Fence API key, mount `API_KEY`, `KEY_ID` and `HOSTNAME` into worksapce pod
- When terminating, check if target workspace pod has mounted Fence API key, and revoke it if it has

### Improvements
- Decoupled workspace: mount `API_KEY`, `KEY_ID` and `HOSTNAME` into worksapce pod at launch
- Decoupled workspace: delete mounted API key from Fence if exists when terminating
- General: get `HOSTNAME` from env var instead of from config file, requires `cloud-automation` PR: https://github.com/uc-cdis/cloud-automation/pull/1717