### PR TITLE
Add ability for prismacloud sidecar container for ECS Fargate

### DIFF
--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -86,6 +86,13 @@ type HatcheryConfig struct {
 	UserVolumeSize         string           `json:"user-volume-size"`
 	Sidecar                SidecarContainer `json:"sidecar"`
 	MoreConfigs            []AppConfigInfo  `json:"more-configs"`
+	PrismaConfig           PrismaConfig     `json:"prisma"`
+}
+
+// Config to allow for Prisma Agents
+type PrismaConfig struct {
+	ConsoleAddress string `json:"console-address"`
+	Enable         bool   `json:"enable"`
 }
 
 // FullHatcheryConfig bucket result from loadConfig

--- a/hatchery/ecs.go
+++ b/hatchery/ecs.go
@@ -635,12 +635,78 @@ func (sess *CREDS) CreateTaskDefinition(input *CreateTaskDefinitionInput, userNa
 		)
 	}
 
+	containerDefinitions := []*ecs.ContainerDefinition{
+		containerDefinition,
+		&sidecarContainerDefinition,
+	}
+
+	if Config.Config.PrismaConfig.Enable {
+		installBundle, err := getInstallBundle()
+		if err != nil {
+			Config.Logger.Print(err, " error getting prisma install bundle")
+			return "", err
+		}
+
+		image, err := getPrismaImage()
+		if err != nil {
+			Config.Logger.Print(err, " error getting prisma image")
+			return "", err
+		}
+
+		Config.Logger.Println(*image)
+
+		paloAltoContainerDefinition := ecs.ContainerDefinition{
+			EntryPoint: aws.StringSlice([]string{
+				"/usr/local/bin/defender",
+				"fargate",
+				"sidecar",
+			}),
+			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("INSTALL_BUNDLE"),
+					Value: aws.String(installBundle.Bundle),
+				},
+				{
+					Name:  aws.String("DEFENDER_TYPE"),
+					Value: aws.String("fargate"),
+				},
+				{
+					Name:  aws.String("FARGATE_TASK"),
+					Value: aws.String(userName),
+				},
+				{
+					Name: aws.String("WS_ADDRESS"),
+					// TODO: Hardcoding in the address for now as the prisma api is returning wrong value
+					Value: aws.String("wss://us-west1.cloud.twistlock.com:443"),
+				},
+				{
+					Name:  aws.String("FILESYSTEM_MONITORING"),
+					Value: aws.String("false"),
+				},
+			},
+			Essential: aws.Bool(true),
+			HealthCheck: &ecs.HealthCheck{
+				Command: aws.StringSlice([]string{
+					"/usr/local/bin/defender",
+					"fargate",
+					"healthcheck",
+				}),
+				Interval:    aws.Int64(5),
+				Retries:     aws.Int64(3),
+				StartPeriod: aws.Int64(1),
+				Timeout:     aws.Int64(5),
+			},
+			Image:            aws.String(*image),
+			Name:             aws.String("TwistlockDefender"),
+			LogConfiguration: logConfiguration,
+		}
+
+		containerDefinitions = append(containerDefinitions, &paloAltoContainerDefinition)
+	}
+
 	resp, err := svc.RegisterTaskDefinition(
 		&ecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions: []*ecs.ContainerDefinition{
-				containerDefinition,
-				&sidecarContainerDefinition,
-			},
+			ContainerDefinitions:    containerDefinitions,
 			Cpu:                     aws.String(input.Cpu),
 			ExecutionRoleArn:        aws.String(input.ExecutionRoleArn),
 			Family:                  aws.String(fmt.Sprintf("%s_%s", input.Type, input.Name)),

--- a/hatchery/ecs.go
+++ b/hatchery/ecs.go
@@ -653,8 +653,6 @@ func (sess *CREDS) CreateTaskDefinition(input *CreateTaskDefinitionInput, userNa
 			return "", err
 		}
 
-		Config.Logger.Println(*image)
-
 		paloAltoContainerDefinition := ecs.ContainerDefinition{
 			EntryPoint: aws.StringSlice([]string{
 				"/usr/local/bin/defender",

--- a/hatchery/prisma.go
+++ b/hatchery/prisma.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 )
 
 type Token struct {
@@ -58,7 +59,7 @@ func getInstallBundle() (*InstallBundle, error) {
 		return nil, err
 	}
 
-	installBundleEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v22.06/defenders/install-bundle?consoleaddr=" + Config.Config.PrismaConfig.ConsoleAddress
+	installBundleEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v22.06/defenders/install-bundle?consoleaddr=" + Config.Config.PrismaConfig.ConsoleAddress + "&defenderType=appEmbedded"
 	var bearer = "Bearer " + *token
 	// Create a new request using http
 	req, err := http.NewRequest("GET", installBundleEndpoint, nil)
@@ -127,8 +128,9 @@ func getPrismaImage() (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sb := string(body)
-	Config.Logger.Print(sb)
+	sb, err := strconv.Unquote(string(body))
+	if err != nil {
+		return nil, err
+	}
 	return &sb, nil
-
 }

--- a/hatchery/prisma.go
+++ b/hatchery/prisma.go
@@ -1,0 +1,134 @@
+package hatchery
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+type Token struct {
+	Token string `json:"token"`
+}
+
+type InstallBundle struct {
+	WsAddress string `json:"wsAddress"`
+	Bundle    string `json:"installBundle"`
+}
+
+func getPrismaToken(username string, password string) (*string, error) {
+	postBody, _ := json.Marshal(map[string]string{
+		"username": username,
+		"password": password,
+	})
+	reqBody := bytes.NewBuffer(postBody)
+	authEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v1/authenticate"
+	resp, err := http.Post(authEndpoint, "application/json", reqBody)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		Config.Logger.Print(string(b))
+		return nil, errors.New("Error authenticating with Prisma Cloud: " + string(b))
+	}
+	//We Read the response body on the line below.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Token
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Println("Invalid response from prisma auth endpoint: " + authEndpoint)
+	}
+
+	return &result.Token, nil
+}
+
+func getInstallBundle() (*InstallBundle, error) {
+	username := os.Getenv("PRISMA_ACCESS_KEY_ID")
+	password := os.Getenv("PRISMA_SECRET_KEY")
+	token, err := getPrismaToken(username, password)
+	if err != nil {
+		return nil, err
+	}
+
+	installBundleEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v22.06/defenders/install-bundle?consoleaddr=" + Config.Config.PrismaConfig.ConsoleAddress
+	var bearer = "Bearer " + *token
+	// Create a new request using http
+	req, err := http.NewRequest("GET", installBundleEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	// add authorization header to the req
+	req.Header.Add("Authorization", bearer)
+
+	// Send req using http Client
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		Config.Logger.Print(string(b))
+		return nil, errors.New("Error getting install bundle: " + string(b))
+	}
+	//We Read the response body on the line below.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var result InstallBundle
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Println("Invalid response from prisma install_bundle endpoint: " + installBundleEndpoint)
+	}
+	return &result, nil
+}
+
+func getPrismaImage() (*string, error) {
+	username := os.Getenv("PRISMA_ACCESS_KEY_ID")
+	password := os.Getenv("PRISMA_SECRET_KEY")
+	token, err := getPrismaToken(username, password)
+	if err != nil {
+		return nil, err
+	}
+
+	imageEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v22.06/defenders/image-name"
+	var bearer = "Bearer " + *token
+	// Create a new request using http
+	req, err := http.NewRequest("GET", imageEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	// add authorization header to the req
+	req.Header.Add("Authorization", bearer)
+
+	// Send req using http Client
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		Config.Logger.Print(string(b))
+		return nil, errors.New("Error getting install bundle: " + string(b))
+	}
+	//We Read the response body on the line below.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	sb := string(body)
+	Config.Logger.Print(sb)
+	return &sb, nil
+
+}


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/BRH-301 

### New Features
- Add ability to configure ECS fargate workspaces to use prismacloud sidecar for security monitoring. 

### Deployment changes
- For this feature to work hatchery needs to have the following environment variables for prisma API key. 

```
PRISMA_ACCESS_KEY_ID
PRISMA_SECRET_KEY
```

These should be populated in `cloud-automation` as long as you create a file called `apikey.json` with the following content under `Gen3Secrets/prisma/` folder and run `gen3 kube-setup-hatchery`

Grab the apikey from prismacloud portal and populate the contents. 

```
{
  "AccessKeyID": "XXXX",
  "SecretKey": "XXXX"
}
```


We also require the following to be added to the hatchery configuration in `cdis-manifest`

```
{
  "user-namespace": "jupyter-pods",
  "sub-dir": "/lw-workspace",
  "user-volume-size": "10Gi",
  "prisma": {
      "enable": true,
      "console-address": "https://us-west1.cloud.twistlock.com/gov-3229443"
    },
    ... rest of hatchery config
```

<img width="1549" alt="image" src="https://user-images.githubusercontent.com/55899496/197823279-992acbb5-e094-421c-a577-642c11d2f454.png">

