### PR TITLE
MIDRC-586 Add compute-environment-type and repurpose instance-type

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -53,8 +53,9 @@ An example manifest entry may look like
             "s3-bucket-whitelist": [
               "ngi-igenomes"
             ],
+            "compute-environment-type": "SPOT",
             "instance-ami": "ami-03392f075059ae3ba",
-            "instance-type": "SPOT",
+            "instance-type": "optimal",
             "instance-min-vcpus": 0,
             "instance-max-vcpus": 9
         }
@@ -99,4 +100,4 @@ An example manifest entry may look like
       * `enabled` is false by default; if true, automatically create AWS resources required to run Nextflow workflows in AWS Batch.
       * `job-image-whitelist` are the only images that are allowed as Nextflow workflow containers. It supports wildcards `?` for a single character and `*` for multiple characters. Warning: setting the whitelist as an empty list allows all images!
       * `s3-bucket-whitelist` are public buckets that Nextflow jobs are allowed to get data objects from. Access to actions "s3:GetObject" and "s3:ListBucket" for `arn:aws:s3:::<bucket>` and `arn:aws:s3:::<bucket>/*` will be granted.
-      * `instance-ami`, `instance-type` ("EC2", "SPOT", "FARGATE" or "FARGATE_SPOT"), `instance-min-vcpus` and `instance-max-vcpus` are AWS Batch Compute Environment settings.
+      * `compute-environment-type` ("EC2", "SPOT", "FARGATE" or "FARGATE_SPOT"), `instance-ami`, `instance-type` ("optimal", "g4dn.xlarge"...), `instance-min-vcpus` and `instance-max-vcpus` are AWS Batch Compute Environment settings.

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -13,13 +13,14 @@ import (
 
 // Configuration specific to Nextflow containers
 type NextflowConfig struct {
-	Enabled           bool     `json:"enabled"`
-	JobImageWhitelist []string `json:"job-image-whitelist"`
-	S3BucketWhitelist []string `json:"s3-bucket-whitelist"`
-	InstanceAMI       string   `json:"instance-ami"`
-	InstanceType      string   `json:"instance-type"`
-	InstanceMinVCpus  int32    `json:"instance-min-vcpus"`
-	InstanceMaxVCpus  int32    `json:"instance-max-vcpus"`
+	Enabled                bool     `json:"enabled"`
+	JobImageWhitelist      []string `json:"job-image-whitelist"`
+	S3BucketWhitelist      []string `json:"s3-bucket-whitelist"`
+	ComputeEnvironmentType string   `json:"compute-environment-type"`
+	InstanceAMI            string   `json:"instance-ami"`
+	InstanceType           string   `json:"instance-type"`
+	InstanceMinVCpus       int32    `json:"instance-min-vcpus"`
+	InstanceMaxVCpus       int32    `json:"instance-max-vcpus"`
 }
 
 // Container Struct to hold the configuration for Pod Container

--- a/hatchery/nextflow.go
+++ b/hatchery/nextflow.go
@@ -573,7 +573,7 @@ func ensureLaunchTemplate(ec2Svc *ec2.EC2, userName string, hostname string) (*s
 		Config.Logger.Printf("Debug: Launch template '%s' already exists", launchTemplateName)
 		return launchTemplate.LaunchTemplates[0].LaunchTemplateName, nil
 	}
-	return nil, fmt.Errorf("More than one launch template with the same name exist: %v", launchTemplate.LaunchTemplates)
+	return nil, fmt.Errorf("more than one launch template with the same name exist: %v", launchTemplate.LaunchTemplates)
 }
 
 // Create AWS Batch compute environment
@@ -631,9 +631,13 @@ func createBatchComputeEnvironment(userName string, hostname string, tagsMap map
 					LaunchTemplateName: launchTemplateName,
 					Version:            aws.String("$Latest"),
 				},
-				MinvCpus: aws.Int64(int64(nextflowConfig.InstanceMinVCpus)),
-				MaxvCpus: aws.Int64(int64(nextflowConfig.InstanceMaxVCpus)),
-				Type:     aws.String(nextflowConfig.InstanceType),
+				InstanceRole:       instanceProfileArn,
+				AllocationStrategy: aws.String("BEST_FIT_PROGRESSIVE"),
+				MinvCpus:           aws.Int64(int64(nextflowConfig.InstanceMinVCpus)),
+				MaxvCpus:           aws.Int64(int64(nextflowConfig.InstanceMaxVCpus)),
+				InstanceTypes:      []*string{aws.String(nextflowConfig.InstanceType)},
+				Type:               aws.String(nextflowConfig.ComputeEnvironmentType),
+				Tags:               tagsMap,
 			},
 			UpdatePolicy: &batch.UpdatePolicy{
 				// existing jobs are not terminated and keep running for up to 30 min after this update
@@ -688,10 +692,10 @@ func createBatchComputeEnvironment(userName string, hostname string, tagsMap map
 				AllocationStrategy: aws.String("BEST_FIT_PROGRESSIVE"),
 				MinvCpus:           aws.Int64(int64(nextflowConfig.InstanceMinVCpus)),
 				MaxvCpus:           aws.Int64(int64(nextflowConfig.InstanceMaxVCpus)),
-				InstanceTypes:      []*string{aws.String("optimal")},
+				InstanceTypes:      []*string{aws.String(nextflowConfig.InstanceType)},
 				SecurityGroupIds:   []*string{securityGroupId},
 				Subnets:            subnets,
-				Type:               aws.String(nextflowConfig.InstanceType),
+				Type:               aws.String(nextflowConfig.ComputeEnvironmentType),
 				Tags:               tagsMap,
 			},
 			Tags: tagsMap,


### PR DESCRIPTION
Jira Ticket: [MIDRC-586](https://ctds-planx.atlassian.net/browse/MIDRC-586)

### Breaking Changes
- The misnamed `nextflow.instance-type` configuration is now `nextflow.compute-environment-type`, used to configure the batch compute environment type. A new `nextflow.instance-type` configuration can be used to configure the batch jobs instance type.


[MIDRC-586]: https://ctds-planx.atlassian.net/browse/MIDRC-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ