### PR TITLE
Add possibility to force hatchery into using cluster internal communication

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -12,6 +12,7 @@ An example manifest entry may look like
     "user-namespace": "jupyter-pods",
     "sub-dir": "/lw-workspace",
     "user-volume-size": "10Gi",
+    "use-internal-services-url": false
     "prisma": {
       "enable": true,
       "console-address": ""
@@ -112,6 +113,7 @@ An example manifest entry may look like
 * `user-namespace` is which namespace the pods will be deployed into.
 * `sub-dir` is the path to Hatchery off the host domain, i.e. if the full domain path is `https://nci-crdc-demo.datacommons.io/lw-workspace` then `sub-dir` is `/lw-workspace`.
 * `user-volume-size` the size of the user volume to be created. Applies to all containers because the user storage is the same across all of them.
+* `use-internal-services-url` Use internal service URLs (http://fence-service/ and http://ambassador-service/) for communication with other services instead of using GEN3_ENDPOINT environmental variable
 * `prisma`: TODO document
 * `pay-models-dynamodb-table` is the name of the DynamoDB table where Hatchery can get users' pay model information
 * `default-pay-model` is the pay model to fall back to when a user does not have a pay model set up in the `pay-models-dynamodb-table` table

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -118,6 +118,7 @@ type HatcheryConfig struct {
 	UserNamespace   string   `json:"user-namespace"`
 	DefaultPayModel PayModel `json:"default-pay-model"`
 	// DisableLocalWS         bool             `json:"disable-local-ws"`
+	UseInteralServicesURL  bool                 `json:"use-internal-services-url"`
 	PayModels              []PayModel           `json:"pay-models"`
 	PayModelsDynamodbTable string               `json:"pay-models-dynamodb-table"`
 	LicenseUserMapsTable   string               `json:"license-user-maps-dynamodb-table"`

--- a/hatchery/helpers.go
+++ b/hatchery/helpers.go
@@ -125,10 +125,21 @@ func MakeARequestWithContext(ctx context.Context, method string, apiEndpoint str
 	return resp, nil
 }
 
+func useInteralSerices() bool{
+	useInternalServicesValue, useInternalServices := os.LookupEnv("GEN3_USE_INTERNAL_SERVICES")
+	if useInternalServices && strings.ToLower(useInternalServicesValue) == "false" {
+		useInternalServices = false
+	}
+	if useInternalServices && useInternalServicesValue == "0" {
+		useInternalServices = false
+	}
+	return useInternalServices
+}
+
 func getFenceURL() string {
 	fenceURL := "http://fence-service/"
 	_, ok := os.LookupEnv("GEN3_ENDPOINT")
-	if ok {
+	if ok && !useInteralSerices() {
 		fenceURL = "https://" + os.Getenv("GEN3_ENDPOINT") + "/user/"
 	}
 	return fenceURL
@@ -137,7 +148,7 @@ func getFenceURL() string {
 func getAmbassadorURL() string {
 	ambassadorURL := "http://ambassador-service/"
 	_, ok := os.LookupEnv("GEN3_ENDPOINT")
-	if ok {
+	if ok && !useInteralSerices() {
 		ambassadorURL = "https://" + os.Getenv("GEN3_ENDPOINT") + "/lw-workspace/proxy/"
 	}
 	return ambassadorURL

--- a/hatchery/helpers.go
+++ b/hatchery/helpers.go
@@ -125,21 +125,10 @@ func MakeARequestWithContext(ctx context.Context, method string, apiEndpoint str
 	return resp, nil
 }
 
-func useInteralSerices() bool{
-	useInternalServicesValue, useInternalServices := os.LookupEnv("GEN3_USE_INTERNAL_SERVICES")
-	if useInternalServices && strings.ToLower(useInternalServicesValue) == "false" {
-		useInternalServices = false
-	}
-	if useInternalServices && useInternalServicesValue == "0" {
-		useInternalServices = false
-	}
-	return useInternalServices
-}
-
 func getFenceURL() string {
 	fenceURL := "http://fence-service/"
 	_, ok := os.LookupEnv("GEN3_ENDPOINT")
-	if ok && !useInteralSerices() {
+	if ok && !Config.Config.UseInteralServicesURL {
 		fenceURL = "https://" + os.Getenv("GEN3_ENDPOINT") + "/user/"
 	}
 	return fenceURL
@@ -148,7 +137,7 @@ func getFenceURL() string {
 func getAmbassadorURL() string {
 	ambassadorURL := "http://ambassador-service/"
 	_, ok := os.LookupEnv("GEN3_ENDPOINT")
-	if ok && !useInteralSerices() {
+	if ok && !Config.Config.UseInteralServicesURL {
 		ambassadorURL = "https://" + os.Getenv("GEN3_ENDPOINT") + "/lw-workspace/proxy/"
 	}
 	return ambassadorURL


### PR DESCRIPTION
Add possibility to force hatchery into using cluster internal communication with other services without removing GEN3_ENDPOINT environmental variable.

Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Added `use-internal-services-url` boolean configuration field that forces hatchery to use cluster-local URLs (like http://fence-service/) even when `GEN3_ENDPOINT` environmental variable is set.

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
