### PR TITLE
Move prisma console version to configuration

### DIFF
--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -108,6 +108,7 @@ type HatcheryConfig struct {
 // Config to allow for Prisma Agents
 type PrismaConfig struct {
 	ConsoleAddress string `json:"console-address"`
+	ConsoleVersion string `json:"console-version"`
 	Enable         bool   `json:"enable"`
 }
 
@@ -188,6 +189,11 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 	for _, payModel := range data.Config.PayModels {
 		user := payModel.User
 		data.PayModelMap[user] = payModel
+	}
+
+	// Set default prisma console version
+	if data.Config.PrismaConfig.ConsoleVersion == "" {
+		data.Config.PrismaConfig.ConsoleVersion = "v32.02"
 	}
 
 	return data, nil

--- a/hatchery/prisma.go
+++ b/hatchery/prisma.go
@@ -59,7 +59,7 @@ func getInstallBundle() (*InstallBundle, error) {
 		return nil, err
 	}
 
-	installBundleEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v22.06/defenders/install-bundle?consoleaddr=" + Config.Config.PrismaConfig.ConsoleAddress + "&defenderType=appEmbedded"
+	installBundleEndpoint := Config.Config.PrismaConfig.ConsoleAddress + fmt.Sprintf("/api/%s/defenders/install-bundle?consoleaddr=", Config.Config.PrismaConfig.ConsoleVersion) + Config.Config.PrismaConfig.ConsoleAddress + "&defenderType=appEmbedded"
 	var bearer = "Bearer " + *token
 	// Create a new request using http
 	req, err := http.NewRequest("GET", installBundleEndpoint, nil)
@@ -101,7 +101,7 @@ func getPrismaImage() (*string, error) {
 		return nil, err
 	}
 
-	imageEndpoint := Config.Config.PrismaConfig.ConsoleAddress + "/api/v32.02/defenders/image-name"
+	imageEndpoint := Config.Config.PrismaConfig.ConsoleAddress + fmt.Sprintf("/api/%s/defenders/image-name", Config.Config.PrismaConfig.ConsoleVersion)
 	var bearer = "Bearer " + *token
 	// Create a new request using http
 	req, err := http.NewRequest("GET", imageEndpoint, nil)


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes

### Improvements
- Read prismacloud console version from config, but fallback to v32.02. 

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
