### PR TITLE
Fix/handle nil licensed users in terminate

### DIFF
--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -218,8 +218,8 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 				data.Logger.Printf("Error in configuration: %v", err)
 				return nil, err
 			}
-			ok := validateContainerLicenseInfo(container.Name, container.License)
-			if !ok {
+			err := validateContainerLicenseInfo(container.Name, container.License)
+			if err != nil {
 				err = fmt.Errorf("container '%s' has an invalid 'license' configuration", container.Name)
 				data.Logger.Printf("Error in configuration: %v", err)
 				return nil, err

--- a/hatchery/gen3licenseusermaps.go
+++ b/hatchery/gen3licenseusermaps.go
@@ -82,7 +82,7 @@ var validateContainerLicenseInfo = func(containerName string, licenseInfo Licens
 	if ok {
 		return nil
 	} else {
-		return errors.New("Error in container LicenseInfo config.")
+		return errors.New("container LicenseInfo is misconfigured")
 	}
 }
 
@@ -112,7 +112,7 @@ var getActiveGen3LicenseUserMaps = func(dbconfig *DbConfig, container Container)
 	targetEnvironment := os.Getenv("GEN3_ENDPOINT")
 	err = validateContainerLicenseInfo(container.Name, container.License)
 	if err != nil {
-		Config.Logger.Printf("Gen3License table info for container is not configured.")
+		Config.Logger.Printf("Gen3License table info for container is not configured or is misconfigured.")
 		return emptyList, nil
 	}
 	if Config.Config.LicenseUserMapsTable == "" || Config.Config.LicenseUserMapsGSI == "" {

--- a/hatchery/gen3licenseusermaps.go
+++ b/hatchery/gen3licenseusermaps.go
@@ -106,11 +106,11 @@ var getActiveGen3LicenseUserMaps = func(dbconfig *DbConfig, container Container)
 	targetEnvironment := os.Getenv("GEN3_ENDPOINT")
 	ok := validateContainerLicenseInfo(container.Name, container.License)
 	if !ok {
-		Config.Logger.Printf("Gen3License table info for container is not configured: %s", err)
+		Config.Logger.Printf("Gen3License table info for container is not configured.")
 		return emptyList, nil
 	}
 	if Config.Config.LicenseUserMapsTable == "" || Config.Config.LicenseUserMapsGSI == "" {
-		Config.Logger.Printf("Gen3License table info is not configured: %s", err)
+		Config.Logger.Printf("Gen3License table info is not configured.")
 		return emptyList, nil
 	}
 
@@ -154,7 +154,7 @@ var getLicenseUserMapsForUser = func(dbconfig *DbConfig, userId string) (gen3Lic
 
 	targetEnvironment := os.Getenv("GEN3_ENDPOINT")
 	if Config.Config.LicenseUserMapsTable == "" || Config.Config.LicenseUserMapsGSI == "" {
-		Config.Logger.Printf("Gen3License table info is not configured: %s", err)
+		Config.Logger.Printf("Gen3License table info is not configured.")
 		return emptyList, nil
 	}
 

--- a/hatchery/gen3licenseusermaps.go
+++ b/hatchery/gen3licenseusermaps.go
@@ -106,7 +106,11 @@ var getActiveGen3LicenseUserMaps = func(dbconfig *DbConfig, container Container)
 	targetEnvironment := os.Getenv("GEN3_ENDPOINT")
 	ok := validateContainerLicenseInfo(container.Name, container.License)
 	if !ok {
-		Config.Logger.Printf("Gen3License not set up for container: %s", err)
+		Config.Logger.Printf("Gen3License table info for container is not configured: %s", err)
+		return emptyList, nil
+	}
+	if Config.Config.LicenseUserMapsTable == "" || Config.Config.LicenseUserMapsGSI == "" {
+		Config.Logger.Printf("Gen3License table info is not configured: %s", err)
 		return emptyList, nil
 	}
 
@@ -149,6 +153,10 @@ var getLicenseUserMapsForUser = func(dbconfig *DbConfig, userId string) (gen3Lic
 	emptyList := []Gen3LicenseUserMap{}
 
 	targetEnvironment := os.Getenv("GEN3_ENDPOINT")
+	if Config.Config.LicenseUserMapsTable == "" || Config.Config.LicenseUserMapsGSI == "" {
+		Config.Logger.Printf("Gen3License table info is not configured: %s", err)
+		return emptyList, nil
+	}
 
 	// Query on global secondary index and filter by userId
 	keyEx1 := expression.Key("environment").Equal(expression.Value(aws.String(targetEnvironment)))

--- a/hatchery/gen3licenseusermaps_test.go
+++ b/hatchery/gen3licenseusermaps_test.go
@@ -165,10 +165,12 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 		Name:    "container-name",
 		License: licenseInfo,
 	}
+	Config.Config.LicenseUserMapsTable = "test_license_user_maps"
+	Config.Config.LicenseUserMapsGSI = "test_gsi"
 
 	// getActiveGen3LicenseUserMaps
 	for _, testcase := range testCases {
-		t.Logf("Testing GetActiveGen3LicenseUserMaps case: %s", testcase.name)
+		t.Logf("Testing GetActiveGen3LicenseUserMaps when %s", testcase.name)
 
 		dbconfig.DynamoDb = &DynamodbMockClient{
 			DynamoDBAPI: nil,
@@ -196,7 +198,7 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 
 	// getLicenseUserMapsForUser
 	for _, testcase := range testCases {
-		t.Logf("Testing getLicenseUserMapsForUser case: %s", testcase.name)
+		t.Logf("Testing getLicenseUserMapsForUser when %s", testcase.name)
 
 		dbconfig.DynamoDb = &DynamodbMockClient{
 			DynamoDBAPI: nil,

--- a/hatchery/gen3licenseusermaps_test.go
+++ b/hatchery/gen3licenseusermaps_test.go
@@ -450,11 +450,11 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 	testCases := []struct {
 		name        string
 		licenseInfo LicenseInfo
-		want        bool
+		expectError bool
 	}{
 		{
-			name: "ValidLicenseInfo",
-			want: true,
+			name:        "ValidLicenseInfo",
+			expectError: false,
 			licenseInfo: LicenseInfo{
 				Enabled:         true,
 				LicenseType:     "test-license-type",
@@ -466,8 +466,8 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "LicenseNotEnabled",
-			want: false,
+			name:        "LicenseNotEnabled",
+			expectError: true,
 			licenseInfo: LicenseInfo{
 				Enabled:         false,
 				LicenseType:     "test-license-type",
@@ -479,8 +479,8 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "MissingLicenseType",
-			want: false,
+			name:        "MissingLicenseType",
+			expectError: true,
 			licenseInfo: LicenseInfo{
 				Enabled:         true,
 				MaxLicenseIds:   3,
@@ -491,8 +491,8 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "ZeroMaxIds",
-			want: false,
+			name:        "ZeroMaxIds",
+			expectError: true,
 			licenseInfo: LicenseInfo{
 				Enabled:         true,
 				LicenseType:     "test-license-type",
@@ -504,15 +504,51 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "MissingG3AutoName",
-			want: false,
+			name:        "MissingG3AutoName",
+			expectError: true,
 			licenseInfo: LicenseInfo{
 				Enabled:         true,
 				LicenseType:     "test-license-type",
 				MaxLicenseIds:   3,
-				G3autoKey:       "test0g3auto-key",
+				G3autoKey:       "test-g3auto-key",
 				FilePath:        "test-file-path",
 				WorkspaceFlavor: "test-workspace-flavor",
+			},
+		},
+		{
+			name:        "MissingG3AutoKey",
+			expectError: true,
+			licenseInfo: LicenseInfo{
+				Enabled:         true,
+				LicenseType:     "test-license-type",
+				MaxLicenseIds:   3,
+				G3autoName:      "test-g3auto-name",
+				FilePath:        "test-file-path",
+				WorkspaceFlavor: "test-workspace-flavor",
+			},
+		},
+		{
+			name:        "MissingFilePath",
+			expectError: true,
+			licenseInfo: LicenseInfo{
+				Enabled:         true,
+				LicenseType:     "test-license-type",
+				MaxLicenseIds:   3,
+				G3autoName:      "test-g3auto-name",
+				G3autoKey:       "test-g3auto-key",
+				WorkspaceFlavor: "test-workspace-flavor",
+			},
+		},
+		{
+			name:        "MissingWorkspaceFlavor",
+			expectError: true,
+			licenseInfo: LicenseInfo{
+				Enabled:       true,
+				LicenseType:   "test-license-type",
+				MaxLicenseIds: 3,
+				G3autoName:    "test-g3auto-name",
+				G3autoKey:     "test-g3auto-key",
+				FilePath:      "test-file-path",
 			},
 		},
 	}
@@ -520,12 +556,13 @@ func Test_ValidateContainerLicenseInfo(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Logf("Testing validateContainerLicenseInfo when %s", testcase.name)
 
-		got := validateContainerLicenseInfo("container-name", testcase.licenseInfo)
-
+		err := validateContainerLicenseInfo("container-name", testcase.licenseInfo)
 		/* Assert */
-		if got != testcase.want {
-			t.Errorf("\nassertion error while testing `validateContainerLicenseInfo`: \nWant:%+v\nGot:%+v", testcase.want, got)
+		if testcase.expectError == true && err == nil {
+			t.Errorf("\nWanted error but got nil.")
+		}
+		if testcase.expectError == false && err != nil {
+			t.Errorf("\nWanted nil but got error: %s", err)
 		}
 	}
-
 }

--- a/hatchery/gen3licenseusermaps_test.go
+++ b/hatchery/gen3licenseusermaps_test.go
@@ -67,18 +67,26 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name            string
-		want            *[]Gen3LicenseUserMap
-		mockQueryOutput *MockOutputPages
+		name               string
+		want               []Gen3LicenseUserMap
+		mockLicenseEnabled bool
+		mockQueryOutput    *MockOutputPages
 	}{
 		{
-			name:            "NoActiveLicenses",
-			want:            &[]Gen3LicenseUserMap{},
-			mockQueryOutput: &MockOutputPages{},
+			name:               "LicenseNotEnabled",
+			want:               []Gen3LicenseUserMap{},
+			mockLicenseEnabled: false,
+			mockQueryOutput:    &MockOutputPages{},
+		},
+		{
+			name:               "NoActiveLicenses",
+			want:               []Gen3LicenseUserMap{},
+			mockLicenseEnabled: true,
+			mockQueryOutput:    &MockOutputPages{},
 		},
 		{
 			name: "SomeActiveLicenses",
-			want: &[]Gen3LicenseUserMap{
+			want: []Gen3LicenseUserMap{
 				{
 					ItemId:      "1234-abcd",
 					Environment: targetEnvironment,
@@ -92,6 +100,7 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 					LicenseId:   2,
 				},
 			},
+			mockLicenseEnabled: true,
 			mockQueryOutput: &MockOutputPages{
 				first: dynamodb.QueryOutput{
 					Items: firstMockItems,
@@ -100,7 +109,7 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 		},
 		{
 			name: "PaginatedActiveLicenses",
-			want: &[]Gen3LicenseUserMap{
+			want: []Gen3LicenseUserMap{
 				{
 					ItemId:      "1234-abcd",
 					Environment: targetEnvironment,
@@ -126,6 +135,7 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 					LicenseId:   4,
 				},
 			},
+			mockLicenseEnabled: true,
 			mockQueryOutput: &MockOutputPages{
 				first: dynamodb.QueryOutput{
 					Items: firstMockItems,
@@ -144,9 +154,12 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 	dbconfig := initializeDbConfig()
 
 	licenseInfo := LicenseInfo{
-		Enabled:       true,
-		LicenseType:   "some-license",
-		MaxLicenseIds: 6,
+		LicenseType:     "some-license",
+		MaxLicenseIds:   6,
+		G3autoName:      "stata-workspace-gen3-license-g3auto",
+		G3autoKey:       "stata_license.txt",
+		FilePath:        "stata.lic",
+		WorkspaceFlavor: "gen3-licensed",
 	}
 	mockContainer := Container{
 		Name:    "container-name",
@@ -155,12 +168,14 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 
 	// getActiveGen3LicenseUserMaps
 	for _, testcase := range testCases {
-		t.Logf("Testing GetActiveGen3LicenseUserMaps")
+		t.Logf("Testing GetActiveGen3LicenseUserMaps case: %s", testcase.name)
 
 		dbconfig.DynamoDb = &DynamodbMockClient{
 			DynamoDBAPI: nil,
 			mockOutput:  testcase.mockQueryOutput,
 		}
+
+		mockContainer.License.Enabled = testcase.mockLicenseEnabled
 
 		/* Act */
 		got, err := getActiveGen3LicenseUserMaps(dbconfig, mockContainer)
@@ -181,7 +196,7 @@ func Test_GetActiveGen3LicenseUserMaps(t *testing.T) {
 
 	// getLicenseUserMapsForUser
 	for _, testcase := range testCases {
-		t.Logf("Testing getLicenseUserMapsForUser")
+		t.Logf("Testing getLicenseUserMapsForUser case: %s", testcase.name)
 
 		dbconfig.DynamoDb = &DynamodbMockClient{
 			DynamoDBAPI: nil,
@@ -305,19 +320,19 @@ func Test_GetNextLicenseId(t *testing.T) {
 		name                          string
 		maxLicenseIds                 int
 		want                          int
-		mockActiveGen3LicenseUserMaps *[]Gen3LicenseUserMap
+		mockActiveGen3LicenseUserMaps []Gen3LicenseUserMap
 	}{
 		{
 			name:                          "Gen3UserLicensesIsEmpty",
 			maxLicenseIds:                 6,
 			want:                          1,
-			mockActiveGen3LicenseUserMaps: &[]Gen3LicenseUserMap{},
+			mockActiveGen3LicenseUserMaps: []Gen3LicenseUserMap{},
 		},
 		{
 			name:          "OneLicenseUsed",
 			maxLicenseIds: 6,
 			want:          2,
-			mockActiveGen3LicenseUserMaps: &[]Gen3LicenseUserMap{
+			mockActiveGen3LicenseUserMaps: []Gen3LicenseUserMap{
 				{
 					IsActive:  "True",
 					LicenseId: 1,
@@ -328,7 +343,7 @@ func Test_GetNextLicenseId(t *testing.T) {
 			name:          "MaxLicensesActive",
 			maxLicenseIds: 2,
 			want:          0,
-			mockActiveGen3LicenseUserMaps: &[]Gen3LicenseUserMap{
+			mockActiveGen3LicenseUserMaps: []Gen3LicenseUserMap{
 				{
 					IsActive:  "True",
 					LicenseId: 1,

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -496,7 +496,7 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 		Config.Logger.Printf(userlicerr.Error())
 	}
 	Config.Logger.Printf("Debug: Active gen3 license user maps %v", activeGen3LicenseUsers)
-	if *activeGen3LicenseUsers == nil || len(*activeGen3LicenseUsers) == 0 {
+	if activeGen3LicenseUsers == nil || len(*activeGen3LicenseUsers) == 0 {
 		Config.Logger.Printf("No active gen3 license sessions for user: %s", userName)
 	} else {
 		for _, v := range *activeGen3LicenseUsers {

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -496,7 +496,7 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 		Config.Logger.Printf(userlicerr.Error())
 	}
 	Config.Logger.Printf("Debug: Active gen3 license user maps %v", activeGen3LicenseUsers)
-	if len(*activeGen3LicenseUsers) == 0 {
+	if *activeGen3LicenseUsers == nil || len(*activeGen3LicenseUsers) == 0 {
 		Config.Logger.Printf("No active gen3 license sessions for user: %s", userName)
 	} else {
 		for _, v := range *activeGen3LicenseUsers {

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -496,10 +496,10 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 		Config.Logger.Printf(userlicerr.Error())
 	}
 	Config.Logger.Printf("Debug: Active gen3 license user maps %v", activeGen3LicenseUsers)
-	if activeGen3LicenseUsers == nil || len(*activeGen3LicenseUsers) == 0 {
+	if len(activeGen3LicenseUsers) == 0 {
 		Config.Logger.Printf("No active gen3 license sessions for user: %s", userName)
 	} else {
-		for _, v := range *activeGen3LicenseUsers {
+		for _, v := range activeGen3LicenseUsers {
 			if v.UserId == userName {
 				Config.Logger.Printf("Debug: updating gen3 license user map as inactive for itemId %s", v.ItemId)
 				_, err := setGen3LicenseUserInactive(dbconfig, v.ItemId)

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -693,7 +693,11 @@ func mountFiles(w http.ResponseWriter, r *http.Request) {
 }
 
 func getMountFileContents(fileId string, userName string) (string, error) {
-	filePathConfigs := getLicenceFilePathConfigs()
+	filePathConfigs, err := getLicenceFilePathConfigs()
+	if err != nil {
+		Config.Logger.Printf("unable to filepaths from config: %v", err)
+		return "", err
+	}
 
 	if fileId == "sample-nextflow-config.txt" {
 		out, err := generateNextflowConfig(userName)

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -695,7 +695,7 @@ func mountFiles(w http.ResponseWriter, r *http.Request) {
 func getMountFileContents(fileId string, userName string) (string, error) {
 	filePathConfigs, err := getLicenceFilePathConfigs()
 	if err != nil {
-		Config.Logger.Printf("unable to filepaths from config: %v", err)
+		Config.Logger.Printf("unable to get filepaths from config: %v", err)
 		return "", err
 	}
 

--- a/hatchery/hatchery_test.go
+++ b/hatchery/hatchery_test.go
@@ -1075,6 +1075,10 @@ aws {
 	licenseInfo := LicenseInfo{
 		Enabled:         true,
 		FilePath:        "license-path.txt",
+		LicenseType:     "test-license-type",
+		MaxLicenseIds:   3,
+		G3autoName:      "test-g3auto-name",
+		G3autoKey:       "test-g3auto-key",
 		WorkspaceFlavor: "licensed-flavor",
 	}
 	Config.ContainersMap = map[string]Container{

--- a/hatchery/hatchery_test.go
+++ b/hatchery/hatchery_test.go
@@ -898,8 +898,8 @@ func Test_TerminateEndpoint(t *testing.T) {
 			return nil
 		}
 
-		getLicenseUserMapsForUser = func(dbconfig *DbConfig, userId string) (*[]Gen3LicenseUserMap, error) {
-			return &[]Gen3LicenseUserMap{}, nil
+		getLicenseUserMapsForUser = func(dbconfig *DbConfig, userId string) ([]Gen3LicenseUserMap, error) {
+			return []Gen3LicenseUserMap{}, nil
 		}
 
 		url := "/terminate"


### PR DESCRIPTION
Fixing:
```
2024/03/18 16:49:33 Terminating workspace for user ABC
2024/03/18 16:49:33 Checking for gen3 license items for user: ABC
2024/03/18 16:49:33 Error in items for user query: InvalidParameter: 2 validation error(s) found.
- minimum field size of 3, QueryInput.IndexName.
- minimum field size of 3, QueryInput.TableName.
2024/03/18 16:49:33 InvalidParameter: 2 validation error(s) found.
- minimum field size of 3, QueryInput.IndexName.
- minimum field size of 3, QueryInput.TableName.
2024/03/18 16:49:33 Debug: Active gen3 license user maps <nil>
2024/03/18 16:49:33 http: panic serving 172.27.100.165:43980: runtime error: invalid memory address or nil pointer dereference
goroutine 3528 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1802 +0xb9
panic({0x18ee0a0, 0x2e004c0})
	/usr/local/go/src/runtime/panic.go:1047 +0x266
github.com/uc-cdis/hatchery/hatchery.terminate({0x1f9cd50, 0xc000add6c0}, 0xc00009ec00)
	/go/src/github.com/uc-cdis/hatchery/hatchery/hatchery.go:499 +0x259
net/http.HandlerFunc.ServeHTTP(0xc0006e0870, {0x1f9cd50, 0xc000add6c0}, 0xc0007978a8)
	/usr/local/go/src/net/http/server.go:2047 +0x2f
net/http.(*ServeMux).ServeHTTP(0x1f9c2d0, {0x1f9cd50, 0xc000add6c0}, 0xc00009ec00)
	/usr/local/go/src/net/http/server.go:2425 +0x149
gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil.TraceAndServe({0x1f76da0, 0xc0005f72c0}, 0xc000797a40)
	/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.33.0/contrib/internal/httputil/trace.go:57 +0xa47
gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http.(*ServeMux).ServeHTTP(0xc0006d50a0, {0x1f9c2d0, 0xc0004fa0e0}, 0xc00009eb00)
	/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.33.0/contrib/net/http/http.go:49 +0x17e
net/http.serverHandler.ServeHTTP({0xc00012b7a0}, {0x1f9c2d0, 0xc0004fa0e0}, 0xc00009eb00)
	/usr/local/go/src/net/http/server.go:2879 +0x43b
net/http.(*conn).serve(0xc0004846e0, {0x1fa4180, 0xc0006e4cf0})
	/usr/local/go/src/net/http/server.go:1930 +0xb08
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3034 +0x4e8
```



### New Features


### Breaking Changes


### Bug Fixes

* Allow `/terminate` to complete when dynamodb query returns nil values

### Improvements


### Dependency updates


### Deployment changes

