### PR TITLE
Update instanceProfile in memory during first launch

### DIFF
--- a/hatchery/nextflow.go
+++ b/hatchery/nextflow.go
@@ -770,6 +770,12 @@ func createEcsInstanceProfile(iamSvc *iam.IAM, name string) (*string, error) {
 			if err != nil {
 				return nil, err
 			}
+			instanceProfile, err = iamSvc.GetInstanceProfile(&iam.GetInstanceProfileInput{
+				InstanceProfileName: aws.String(name),
+			})
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Update instanceProfile in memory during first launch. 
  - During first launch instanceProfile is not found, then we create one but never update the reference in memory that is returned later, resulting in a panic as it can't find the item in memory. 
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
