### PR TITLE
Avoid us-east-1e when setting up nextflow subnets

### DIFF
--- a/hatchery/nextflow.go
+++ b/hatchery/nextflow.go
@@ -1091,6 +1091,7 @@ func setupSubnet(subnetName string, cidr string, vpcid string, ec2Svc *ec2.EC2) 
 
 	// Avoid us-east-1e as it is technically neglected, and does not have modern instance types.
 	// Find a suitable availability zone that is not us-east-1e
+	// as of june 2024, we cannot launch instance types of g4dn in us-east-1e
 	var selectedZone string
 	for _, zone := range describeZonesOutput.AvailabilityZones {
 		if *zone.State == "available" && !strings.EqualFold(*zone.ZoneName, "us-east-1e") {

--- a/hatchery/nextflow.go
+++ b/hatchery/nextflow.go
@@ -660,6 +660,12 @@ func createBatchComputeEnvironment(nextflowGlobalConfig NextflowGlobalConfig, ne
 			return "", err
 		}
 
+		subnets := []*string{}
+		for _, subnet := range subnetids {
+			s := subnet
+			subnets = append(subnets, &s)
+		}
+
 		// update any settings that may have changed in the config
 		// TODO also make sure it is pointing at the correct subnets - if the VPC is deleted,
 		// we should recreate the compute environment as well because it will be pointing at
@@ -678,6 +684,7 @@ func createBatchComputeEnvironment(nextflowGlobalConfig NextflowGlobalConfig, ne
 				MinvCpus:           aws.Int64(int64(nextflowConfig.InstanceMinVCpus)),
 				MaxvCpus:           aws.Int64(int64(nextflowConfig.InstanceMaxVCpus)),
 				InstanceTypes:      []*string{aws.String(nextflowConfig.InstanceType)},
+				Subnets:            subnets,
 				Type:               aws.String(nextflowConfig.ComputeEnvironmentType),
 				Tags:               tagsMap,
 			},


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- This avoids us-east-1e as AZ for subnets when setting up subnets for nextflow. 
- us-east-1e is technically neglected by AWS and does not seem to be receiving any updated instance types. 

references:
https://coding-stream-of-consciousness.com/2021/08/27/listing-supported-availability-zones-azs-for-instance-types-in-aws/
https://www.reddit.com/r/aws/comments/9oy2iy/your_requested_instance_type_m5large_is_not/
https://wolfman.dev/posts/exclude-use1-az3/ 


### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
