### PR TITLE
MIDRC-536 MIDRC-653 Add expiration bucket lifecycle rule

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -33,6 +33,7 @@ An example manifest entry may look like
       "lifecycle-pre-stop": ["su", "-c", "cd /data; for f in *; do fusermount -u $f; rm -rf $f; done", "-s", "/bin/sh", "jovyan"]
     },
     "nextflow-global": {
+      "s3-objects-expiration-days": 30,
       "sample-config-public-image": "",
       "imagebuilder-reader-role-arn": ""
     },
@@ -126,6 +127,7 @@ An example manifest entry may look like
     * `command` a string array as the command to run in the container overriding the default.
     * `lifecycle-pre-stop` a string array as the container prestop command.
 * `nextflow-global` is for global configuration specific to Nextflow containers.
+    * `s3-objects-expiration-days` (int, default 30): objects created in S3 by Nextflow are deleted after the specified number of days.
     * `sample-config-public-image`: a publicly-accessible image that any user can pull to test Nextflow workflows. Will be mentioned in the auto-generated sample configuration and documentation when a user launches a Nextflow workspace.
     * `imagebuilder-reader-role-arn`: see the [nextflow-global.imagebuilder-reader-role-arn section](/doc/explanation/nextflow.md#nextflow-globalimagebuilder-reader-role-arn) of the Nextflow workspaces documentation.
 * `containers` is the list of workspaces available to be run by this instance of Hatchery. Each container must be a single image and expose a web server.

--- a/hatchery/authz_test.go
+++ b/hatchery/authz_test.go
@@ -256,7 +256,7 @@ func TestIsUserAuthorizedForResourcePaths(t *testing.T) {
 	}
 
 	resourcePaths := []string{"/workspace/abc", "/workspace/xyz"}
-	expectedRequestBody := "{ \"requests\": [{\"resource\": \"/workspace/abc\", \"action\": {\"service\": \"jupyterhub\", \"method\": \"launch\"}},{\"resource\": \"/workspace/xyz\", \"action\": {\"service\": \"jupyterhub\", \"method\": \"launch\"}}]}"
+	expectedRequestBody := "{\"user\": {\"token\": \"accessToken\"}, \"requests\": [{\"resource\": \"/workspace/abc\", \"action\": {\"service\": \"jupyterhub\", \"method\": \"launch\"}},{\"resource\": \"/workspace/xyz\", \"action\": {\"service\": \"jupyterhub\", \"method\": \"launch\"}}]}"
 
 	originalArboristAuthRequest := arboristAuthRequest
 	defer func() {
@@ -267,7 +267,7 @@ func TestIsUserAuthorizedForResourcePaths(t *testing.T) {
 		t.Logf("Running test case: '%s'", testCase.name)
 
 		// mock the call to arborist
-		arboristAuthRequest = func(accessToken string, body string) (bool, error) {
+		arboristAuthRequest = func(body string) (bool, error) {
 			if testCase.arboristError {
 				return false, fmt.Errorf("mocking an error while making call to arborist")
 			}

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -13,6 +13,7 @@ import (
 
 // Global configuration shared by all Nextflow containers
 type NextflowGlobalConfig struct {
+	S3ObjectsExpirationDays   int    `json:"s3-objects-expiration-days"`
 	SampleConfigPublicImage   string `json:"sample-config-public-image"`
 	ImageBuilderReaderRoleArn string `json:"imagebuilder-reader-role-arn"`
 }

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -435,10 +435,12 @@ func launch(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		Config.Logger.Printf(err.Error())
 	}
+	Config.Logger.Printf("DEBUG: allpaymodels = %v", allpaymodels)
 	if allpaymodels == nil { // Commons with no concept of paymodels
 		err = createLocalK8sPod(r.Context(), hash, userName, accessToken, envVars)
 	} else {
 		payModel := allpaymodels.CurrentPayModel
+		Config.Logger.Printf("DEBUG: payModel = %v", payModel)
 		if payModel == nil {
 			Config.Logger.Printf("Current Paymodel is not set. Launch forbidden for user %s", userName)
 			http.Error(w, "Current Paymodel is not set. Launch forbidden", http.StatusInternalServerError)

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -435,12 +435,10 @@ func launch(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		Config.Logger.Printf(err.Error())
 	}
-	Config.Logger.Printf("DEBUG: allpaymodels = %v", allpaymodels)
 	if allpaymodels == nil { // Commons with no concept of paymodels
 		err = createLocalK8sPod(r.Context(), hash, userName, accessToken, envVars)
 	} else {
 		payModel := allpaymodels.CurrentPayModel
-		Config.Logger.Printf("DEBUG: payModel = %v", payModel)
 		if payModel == nil {
 			Config.Logger.Printf("Current Paymodel is not set. Launch forbidden for user %s", userName)
 			http.Error(w, "Current Paymodel is not set. Launch forbidden", http.StatusInternalServerError)

--- a/hatchery/helpers.go
+++ b/hatchery/helpers.go
@@ -218,6 +218,9 @@ func getAwsAccountId(sess *session.Session, awsConfig *aws.Config) (string, erro
 	if err != nil {
 		return "", err
 	}
+	if *req.Account == "" {
+		return "", fmt.Errorf("unable to find AWS account ID: STS GetCallerIdentity returned: %v", *req)
+	}
 	return *req.Account, nil
 }
 


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MIDRC-536, https://ctds-planx.atlassian.net/browse/MIDRC-653

### New Features
- Add `nextflow-global.s3-objects-expiration-days` setting to configure when to delete objects created in S3 by Nextflow

### Breaking Changes

### Bug Fixes
- Fix a bug when making requests to Arborist to check users' container authorization

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
