### PR TITLE
Skip node selector, for dev/single node-clusters

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -115,6 +115,7 @@ An example manifest entry may look like
 * `sub-dir` is the path to Hatchery off the host domain, i.e. if the full domain path is `https://nci-crdc-demo.datacommons.io/lw-workspace` then `sub-dir` is `/lw-workspace`.
 * `user-volume-size` the size of the user volume to be created. Applies to all containers because the user storage is the same across all of them.
 * `use-internal-services-url` Use internal service URLs (http://fence-service/ and http://ambassador-service/) for communication with other services instead of using GEN3_ENDPOINT environmental variable
+* `skip-node-selector` if set to `true`, will not set a node selector for the pods, which will be scheduled on any node. Useful for single-node clusters.
 * `prisma`: TODO document
 * `pay-models-dynamodb-table` is the name of the DynamoDB table where Hatchery can get users' pay model information
 * `default-pay-model` is the pay model to fall back to when a user does not have a pay model set up in the `pay-models-dynamodb-table` table

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -119,6 +119,7 @@ type HatcheryConfig struct {
 	UserNamespace   string   `json:"user-namespace"`
 	DefaultPayModel PayModel `json:"default-pay-model"`
 	// DisableLocalWS         bool             `json:"disable-local-ws"`
+	SkipNodeSelector       bool                 `json:"skip-node-selector"`
 	UseInteralServicesURL  bool                 `json:"use-internal-services-url"`
 	PayModels              []PayModel           `json:"pay-models"`
 	PayModelsDynamodbTable string               `json:"pay-models-dynamodb-table"`

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -497,6 +497,15 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 		})
 	}
 
+	tolerations := []k8sv1.Toleration{}
+	nodeSelector := map[string]string{}
+	if !Config.Config.SkipNodeSelector {
+		nodeSelector = map[string]string{
+			"role": "jupyter",
+		}
+		tolerations = []k8sv1.Toleration{{Key: "role", Operator: "Equal", Value: "jupyter", Effect: "NoSchedule", TolerationSeconds: nil}}
+	}
+
 	pod = &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName,
@@ -543,11 +552,9 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 			},
 			RestartPolicy:    k8sv1.RestartPolicyNever,
 			ImagePullSecrets: []k8sv1.LocalObjectReference{},
-			NodeSelector: map[string]string{
-				"role": "jupyter",
-			},
-			Tolerations: []k8sv1.Toleration{{Key: "role", Operator: "Equal", Value: "jupyter", Effect: "NoSchedule", TolerationSeconds: nil}},
-			Volumes:     volumes,
+			NodeSelector:     nodeSelector,
+			Tolerations:      tolerations,
+			Volumes:          volumes,
 		},
 	}
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features
- Add `skip-node-selector` configuration to skipping adding a nodeselector to be able to run workspaces in single node clusters. If used in a dev environment without public DNS you should also use `use-internal-services-url` configuration to talk directly to fence/ ambassador. 


### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
