### PR TITLE
Feat/assume role

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -18,6 +18,7 @@ An example manifest entry may look like
       "console-address": ""
     },
     "pay-models-dynamodb-table": "dynamodb-table-name",
+    "pay-models-dynamodb-arn": "arn:aws:iam::12345:role/other-role"
     "default-pay-model": {
       "workspace_type": "Trial Workspace",
       "local": true
@@ -118,6 +119,7 @@ An example manifest entry may look like
 * `skip-node-selector` if set to `true`, will not set a node selector for the pods, which will be scheduled on any node. Useful for single-node clusters.
 * `prisma`: TODO document
 * `pay-models-dynamodb-table` is the name of the DynamoDB table where Hatchery can get users' pay model information
+* `pay-models-dynamodb-arn` specify a cross-account role if the DynamoDB table is stored in another AWS account
 * `default-pay-model` is the pay model to fall back to when a user does not have a pay model set up in the `pay-models-dynamodb-table` table
 * `license-user-maps-dynamodb-table` is the optional table name if using dynamodb for managing user sessions of gen3-licensed workspaces.
 * `license-user-maps-global-seconday-index` the global secondary index for active users in the license-user-maps table.

--- a/hatchery/authz.go
+++ b/hatchery/authz.go
@@ -212,7 +212,7 @@ var isUserAuthorizedForPayModels = func(userName string, allowedPayModels []stri
 	}
 	currentPayModel, err := getCurrentPayModel(userName)
 	if err != nil {
-		Config.Logger.Printf(fmt.Sprintf("Failed to get current pay model for user '%s', unable to check if user is authorized to launch container. Error: %v", userName, err))
+		Config.Logger.Printf(fmt.Sprintf("Failed to get current pay model for user '%s', unable to check if user is authorized to launch container. Error: %s", userName, err.Error()))
 		return false, nil
 	}
 

--- a/hatchery/authz.go
+++ b/hatchery/authz.go
@@ -212,7 +212,7 @@ var isUserAuthorizedForPayModels = func(userName string, allowedPayModels []stri
 	}
 	currentPayModel, err := getCurrentPayModel(userName)
 	if err != nil {
-		Config.Logger.Printf(fmt.Sprintf("Failed to get current pay model for user '%s', unable to check if user is authorized to launch container. Error: %s", userName, err.Error()))
+		Config.Logger.Printf("Failed to get current pay model for user '%s', unable to check if user is authorized to launch container. Error: %s", userName, err.Error())
 		return false, nil
 	}
 

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -225,7 +225,7 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 		data.Logger.Printf("Checking license config info for container %s", container.Name)
 		if container.License.Enabled {
 			if data.Config.LicenseUserMapsTable == "" {
-				err = fmt.Errorf("no 'license-user-maps-dynamodb-table' in configuration but license is configured for container %s", container.Name)
+				err = fmt.Errorf("no 'license-user-maps-dynamodb-table' in configuration but license is configured for container '%s'", container.Name)
 				data.Logger.Printf("Error in configuration: %v", err)
 				return nil, err
 			}

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -123,6 +123,7 @@ type HatcheryConfig struct {
 	UseInteralServicesURL  bool                 `json:"use-internal-services-url"`
 	PayModels              []PayModel           `json:"pay-models"`
 	PayModelsDynamodbTable string               `json:"pay-models-dynamodb-table"`
+	PayModelsDynamodbArn   string               `json:"pay-models-dynamodb-arn"`
 	LicenseUserMapsTable   string               `json:"license-user-maps-dynamodb-table"`
 	LicenseUserMapsGSI     string               `json:"license-user-maps-global-secondary-index"`
 	License                LicenseInfo          `json:"license"`
@@ -239,6 +240,9 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 
 	if data.Config.PayModelsDynamodbTable == "" {
 		data.Logger.Printf("Warning: no 'pay-models-dynamodb-table' in configuration: will be unable to query pay model data in DynamoDB")
+	}
+	if data.Config.PayModelsDynamodbArn == "" {
+		data.Logger.Printf("Warning: no 'pay-models-dynamodb-arn' in configuration: we will set up DynamoDB client with regular creds")
 	}
 
 	for _, payModel := range data.Config.PayModels {

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -217,7 +217,7 @@ func LoadConfig(configFilePath string, loggerIn *log.Logger) (config *FullHatche
 		data.Logger.Printf("Warning: no 'license-user-maps-dynamodb-table' in configuration: will be unable to store license-user-map data in DynamoDB")
 	} else if data.Config.LicenseUserMapsGSI == "" {
 		err = fmt.Errorf("'license-user-maps-dynamodb-table' is present but missing 'license-user-maps-global-secondary-index'")
-		data.Logger.Printf("Error in config: %v", err)
+		data.Logger.Printf("Error in configuration: %v", err)
 		return nil, err
 	}
 

--- a/hatchery/config_test.go
+++ b/hatchery/config_test.go
@@ -40,6 +40,37 @@ func TestLoadConfig(t *testing.T) {
 	config.Logger.Printf("config_test marshalled config: %v", string(jsBytes))
 }
 
+func TestMissingConfigFile(t *testing.T) {
+	defer SetupAndTeardownTest()()
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	/* Act */
+	_, err := LoadConfig("../testData/testDoesNotExist.json", logger)
+
+	/* Assert */
+	if err == nil {
+		t.Errorf("failed to catch missing config file. err should have message but got nil.")
+	}
+	expectedSubString := "no such file or directory"
+	if !strings.Contains(err.Error(), expectedSubString) {
+		t.Errorf("Unexpected error message: \nWant substring :\n\t %+v,\n in actual error:\n\t %+v",
+			expectedSubString,
+			err)
+	}
+
+	logOutput := buf.String()
+	logLines := strings.Split(logOutput, "\n")
+	lastLine := logLines[len(logLines)-2]
+	if !strings.Contains(lastLine, expectedSubString) {
+		t.Errorf("Unexpected logger message: \nWant substring :\n\t %+v,\n in actual error:\n\t%+v",
+			expectedSubString,
+			lastLine)
+	}
+
+}
+
 func TestLoadConfigMissingGSI(t *testing.T) {
 	defer SetupAndTeardownTest()()
 
@@ -94,6 +125,43 @@ func TestLoadConfigMissingLicenseTable(t *testing.T) {
 	}
 	containerName := "(Generic, Limited Gen3-licensed) Stata Notebook"
 	expectedErrorMessage := fmt.Sprintf("no 'license-user-maps-dynamodb-table' in configuration but license is configured for container %s", containerName)
+	expectedError := errors.New(expectedErrorMessage)
+	if err.Error() != expectedError.Error() {
+		t.Errorf("Unexpected error message: \nWant:\n\t %+v,\nGot:\n\t %+v",
+			expectedError,
+			err)
+	}
+
+	expectedLoggerMessage := fmt.Sprintf("Error in configuration: %v", expectedErrorMessage)
+	logOutput := buf.String()
+	logLines := strings.Split(logOutput, "\n")
+	lastLine := logLines[len(logLines)-2]
+	if lastLine != expectedLoggerMessage {
+		t.Errorf("Unexpected logger message: \nWant:\n\t %+v,\nGot:\n\t %+v",
+			expectedLoggerMessage,
+			lastLine)
+	}
+
+}
+
+func TestInvalidLicense(t *testing.T) {
+	defer SetupAndTeardownTest()()
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	/* Act */
+	config, err := LoadConfig("../testData/testConfigInvalidLicense.json", logger)
+
+	/* Assert */
+	if config != nil {
+		t.Errorf("Config load should have failed with config=nil. Got %v", config)
+	}
+	if err == nil {
+		t.Errorf("failed to catch invalid license config. err should have message but got nil.")
+	}
+	configName := "Test-missing-license-type"
+	expectedErrorMessage := fmt.Sprintf("container '%s' has an invalid 'license' configuration", configName)
 	expectedError := errors.New(expectedErrorMessage)
 	if err.Error() != expectedError.Error() {
 		t.Errorf("Unexpected error message: \nWant:\n\t %+v,\nGot:\n\t %+v",

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -415,7 +415,7 @@ func launch(w http.ResponseWriter, r *http.Request) {
 		dbconfig := initializeDbConfig()
 		activeGen3LicenseUsers, err := getActiveGen3LicenseUserMaps(dbconfig, Config.ContainersMap[hash])
 		if err != nil {
-			Config.Logger.Printf(err.Error())
+			Config.Logger.Printf("error when getting active Gen3-licensed users: %s", err.Error())
 		}
 		// Check for config max
 		nextLicenseId := getNextLicenseId(activeGen3LicenseUsers, Config.ContainersMap[hash].License.MaxLicenseIds)
@@ -425,7 +425,7 @@ func launch(w http.ResponseWriter, r *http.Request) {
 		}
 		newItem, err := createGen3LicenseUserMap(dbconfig, userName, nextLicenseId, Config.ContainersMap[hash])
 		if err != nil {
-			Config.Logger.Printf(err.Error())
+			Config.Logger.Printf("error when adding active Gen3-licensed user: %s", err.Error())
 		}
 		Config.Logger.Printf("Created new license-user-map item: %v", newItem)
 
@@ -433,7 +433,7 @@ func launch(w http.ResponseWriter, r *http.Request) {
 
 	allpaymodels, err := getPayModelsForUser(userName)
 	if err != nil {
-		Config.Logger.Printf(err.Error())
+		Config.Logger.Printf("error when getting paymodels for user: %s", err.Error())
 	}
 	if allpaymodels == nil { // Commons with no concept of paymodels
 		err = createLocalK8sPod(r.Context(), hash, userName, accessToken, envVars)

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -492,7 +492,7 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 	dbconfig := initializeDbConfig()
 	activeGen3LicenseUsers, userlicerr := getLicenseUserMapsForUser(dbconfig, userName)
 	if userlicerr != nil {
-		Config.Logger.Printf(userlicerr.Error())
+		Config.Logger.Printf("Cannot check gen3 license items for user: %s", userlicerr.Error())
 	}
 	Config.Logger.Printf("Debug: Active gen3 license user maps %v", activeGen3LicenseUsers)
 	if len(activeGen3LicenseUsers) == 0 {
@@ -503,7 +503,7 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 				Config.Logger.Printf("Debug: updating gen3 license user map as inactive for itemId %s", v.ItemId)
 				_, err := setGen3LicenseUserInactive(dbconfig, v.ItemId)
 				if err != nil {
-					Config.Logger.Printf(err.Error())
+					Config.Logger.Printf("cannot set gen3 license for user: %s", err.Error())
 				}
 			}
 		}
@@ -519,7 +519,7 @@ func terminate(w http.ResponseWriter, r *http.Request) {
 
 	payModel, err := getCurrentPayModel(userName)
 	if err != nil {
-		Config.Logger.Printf(err.Error())
+		Config.Logger.Printf("Cannot get current paymodel for user: %s", err.Error())
 	}
 	if payModel != nil && payModel.Ecs {
 		_, err = terminateEcsWorkspace(r.Context(), userName, accessToken, payModel.AWSAccountId)

--- a/hatchery/paymodels.go
+++ b/hatchery/paymodels.go
@@ -20,12 +20,10 @@ var getPayModelTableCreds = func(sess *session.Session) aws.Config {
 
 	// Assume a new role if we have a pay model arn
 	if Config.Config.PayModelsDynamodbArn != "" {
-		fmt.Println("Got the ARN for assume role")
 		awsConfig = aws.Config{
 			Credentials: stscreds.NewCredentials(sess, Config.Config.PayModelsDynamodbArn),
 		}
 	} else {
-		fmt.Println("Regular creds")
 		awsConfig = aws.Config{}
 	}
 	return awsConfig

--- a/hatchery/paymodels.go
+++ b/hatchery/paymodels.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
@@ -13,6 +14,23 @@ import (
 
 var ErrNopaymodels = errors.New("no paymodels found")
 
+var getPayModelTableCreds = func(sess *session.Session) aws.Config {
+	// credentials for pay model dynamodb table
+	var awsConfig aws.Config
+
+	// Assume a new role if we have a pay model arn
+	if Config.Config.PayModelsDynamodbArn != "" {
+		fmt.Println("Got the ARN for assume role")
+		awsConfig = aws.Config{
+			Credentials: stscreds.NewCredentials(sess, Config.Config.PayModelsDynamodbArn),
+		}
+	} else {
+		fmt.Println("Regular creds")
+		awsConfig = aws.Config{}
+	}
+	return awsConfig
+}
+
 var payModelsFromDatabase = func(userName string, current bool) (payModels *[]PayModel, err error) {
 	// query pay model data for this user from DynamoDB
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
@@ -20,7 +38,8 @@ var payModelsFromDatabase = func(userName string, current bool) (payModels *[]Pa
 			Region: aws.String("us-east-1"),
 		},
 	}))
-	dynamodbSvc := dynamodb.New(sess)
+	payModelTableConfig := getPayModelTableCreds(sess)
+	dynamodbSvc := dynamodb.New(sess, &payModelTableConfig)
 
 	filtActive := expression.Name("request_status").Equal(expression.Value("active"))
 	filtAboveLimit := expression.Name("request_status").Equal(expression.Value("above limit"))
@@ -173,7 +192,8 @@ var setCurrentPaymodel = func(userName string, workspaceid string) (paymodel *Pa
 			Region: aws.String("us-east-1"),
 		},
 	}))
-	dynamodbSvc := dynamodb.New(sess)
+	payModelTableConfig := getPayModelTableCreds(sess)
+	dynamodbSvc := dynamodb.New(sess, &payModelTableConfig)
 	pm_db, err := payModelsFromDatabase(userName, false)
 	if err != nil {
 		return nil, err
@@ -211,7 +231,8 @@ var resetCurrentPaymodel = func(userName string) error {
 			Region: aws.String("us-east-1"),
 		},
 	}))
-	dynamodbSvc := dynamodb.New(sess)
+	payModelTableConfig := getPayModelTableCreds(sess)
+	dynamodbSvc := dynamodb.New(sess, &payModelTableConfig)
 
 	return resetCurrentPaymodelInDB(userName, dynamodbSvc)
 }

--- a/hatchery/paymodels_test.go
+++ b/hatchery/paymodels_test.go
@@ -488,3 +488,35 @@ func Test_PayModelFromConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDefaultPayModel(t *testing.T) {
+	defer SetupAndTeardownTest()()
+
+	defaultPayModelForTest := &PayModel{
+		Name:  "Trial Workspace",
+		Local: true,
+	}
+
+	configWithPayModel := &FullHatcheryConfig{
+		Config: HatcheryConfig{
+			DefaultPayModel: *defaultPayModelForTest,
+		},
+	}
+
+	/* Setup */
+	Config = configWithPayModel
+
+	/* Act */
+	got, err := getDefaultPayModel()
+
+	/* Assert */
+	if err != nil {
+		t.Errorf("Unexpected error. Should be nil but got %v", err)
+	}
+	if !reflect.DeepEqual(got, defaultPayModelForTest) {
+		t.Errorf("Unexpected output: \nWant:\n\t %+v,\n Got:\n\t %+v",
+			defaultPayModelForTest,
+			got)
+	}
+
+}

--- a/hatchery/paymodels_test.go
+++ b/hatchery/paymodels_test.go
@@ -9,6 +9,38 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+func TestGetDefaultPayModel(t *testing.T) {
+	defer SetupAndTeardownTest()()
+
+	defaultPayModelForTest := &PayModel{
+		Name:  "Trial Workspace",
+		Local: true,
+	}
+
+	configWithPayModel := &FullHatcheryConfig{
+		Config: HatcheryConfig{
+			DefaultPayModel: *defaultPayModelForTest,
+		},
+	}
+
+	/* Setup */
+	Config = configWithPayModel
+
+	/* Act */
+	got, err := getDefaultPayModel()
+
+	/* Assert */
+	if err != nil {
+		t.Errorf("Unexpected error. Should be nil but got %v", err)
+	}
+	if !reflect.DeepEqual(got, defaultPayModelForTest) {
+		t.Errorf("Unexpected output: \nWant:\n\t %+v,\n Got:\n\t %+v",
+			defaultPayModelForTest,
+			got)
+	}
+
+}
+
 func Test_GetCurrentPayModel(t *testing.T) {
 	defer SetupAndTeardownTest()()
 
@@ -487,36 +519,4 @@ func Test_PayModelFromConfig(t *testing.T) {
 				testcase.name, testcase.want, got)
 		}
 	}
-}
-
-func TestGetDefaultPayModel(t *testing.T) {
-	defer SetupAndTeardownTest()()
-
-	defaultPayModelForTest := &PayModel{
-		Name:  "Trial Workspace",
-		Local: true,
-	}
-
-	configWithPayModel := &FullHatcheryConfig{
-		Config: HatcheryConfig{
-			DefaultPayModel: *defaultPayModelForTest,
-		},
-	}
-
-	/* Setup */
-	Config = configWithPayModel
-
-	/* Act */
-	got, err := getDefaultPayModel()
-
-	/* Assert */
-	if err != nil {
-		t.Errorf("Unexpected error. Should be nil but got %v", err)
-	}
-	if !reflect.DeepEqual(got, defaultPayModelForTest) {
-		t.Errorf("Unexpected output: \nWant:\n\t %+v,\n Got:\n\t %+v",
-			defaultPayModelForTest,
-			got)
-	}
-
 }

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -400,14 +400,14 @@ func buildPod(hatchConfig *FullHatcheryConfig, hatchApp *Container, userName str
 	//hatchConfig.Logger.Printf("sidecar configured")
 
 	var lifeCycle = k8sv1.Lifecycle{}
-	if hatchApp.LifecyclePreStop != nil && len(hatchApp.LifecyclePreStop) > 0 {
+	if len(hatchApp.LifecyclePreStop) > 0 {
 		lifeCycle.PreStop = &k8sv1.LifecycleHandler{
 			Exec: &k8sv1.ExecAction{
 				Command: hatchApp.LifecyclePreStop,
 			},
 		}
 	}
-	if hatchApp.LifecyclePostStart != nil && len(hatchApp.LifecyclePostStart) > 0 {
+	if len(hatchApp.LifecyclePostStart) > 0 {
 		lifeCycle.PostStart = &k8sv1.LifecycleHandler{
 			Exec: &k8sv1.ExecAction{
 				Command: hatchApp.LifecyclePostStart,

--- a/hatchery/ram.go
+++ b/hatchery/ram.go
@@ -30,7 +30,7 @@ func acceptTransitGatewayShare(pm *PayModel, sess *session.Session, ramArn *stri
 	})
 	if err != nil {
 		// Log error
-		Config.Logger.Printf(err.Error())
+		Config.Logger.Printf("cannot get resource share: %s", err.Error())
 		return err
 	}
 	if len(exResourceShares.ResourceShares) == 0 {
@@ -39,7 +39,7 @@ func acceptTransitGatewayShare(pm *PayModel, sess *session.Session, ramArn *stri
 		err := svc.acceptTGWShare(ramArn)
 		if err != nil {
 			// Log error
-			Config.Logger.Printf(err.Error())
+			Config.Logger.Printf("Cannot accept transit gateway share: %s", err.Error())
 			return err
 		}
 	} else {
@@ -64,7 +64,7 @@ func (creds *CREDS) acceptTGWShare(ramArn *string) error {
 	resourceShareInvitation, err := svc.GetResourceShareInvitations(ramInvitationInput)
 	if err != nil {
 		// Log error
-		Config.Logger.Printf(err.Error())
+		Config.Logger.Printf("Cannot get resources share invitations: %s", err.Error())
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -36,12 +36,12 @@ func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	cleanPath, err := verifyPath(configPath)
 	if err != nil {
-		logger.Printf(fmt.Sprintf("Failed to load config - got %v", err))
+		logger.Printf(fmt.Sprintf("Failed to load config - got %s", err.Error()))
 		return
 	}
 	config, err := hatchery.LoadConfig(cleanPath, logger)
 	if err != nil {
-		config.Logger.Printf(fmt.Sprintf("Failed to load config - got %v", err))
+		config.Logger.Printf(fmt.Sprintf("Failed to load config - got %s", err.Error()))
 		return
 	}
 	hatchery.Config = config

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -36,12 +35,12 @@ func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	cleanPath, err := verifyPath(configPath)
 	if err != nil {
-		logger.Printf(fmt.Sprintf("Failed to load config - got %s", err.Error()))
+		logger.Printf("Failed to load config - got %s", err.Error())
 		return
 	}
 	config, err := hatchery.LoadConfig(cleanPath, logger)
 	if err != nil {
-		config.Logger.Printf(fmt.Sprintf("Failed to load config - got %s", err.Error()))
+		config.Logger.Printf("Failed to load config - got %s", err.Error())
 		return
 	}
 	hatchery.Config = config

--- a/testData/testConfigInvalidLicense.json
+++ b/testData/testConfigInvalidLicense.json
@@ -3,6 +3,7 @@
     "sub-dir": "/lw-workspace",
     "user-volume-size": "10Gi",
     "license-user-maps-dynamodb-table": "gen3-license-user-maps",
+    "license-user-maps-global-secondary-index": "activeUsersIndex",
     "sidecar": {
       "cpu-limit": "1.0",
       "memory-limit": "256Mi",
@@ -19,14 +20,13 @@
         "target-port": 8888,
         "cpu-limit": "1.0",
         "memory-limit": "2Gi",
-        "name": "Test-missing-license-GSI",
+        "name": "Test-missing-license-type",
         "image": "quay.io/cdis/jupyter-pystata-gen3-licensed:master",
         "env": {
           "FRAME_ANCESTORS": "https://dev.planx-pla.net"
         },
         "license": {
           "enabled": true,
-          "license-type": "TEST-LICENSE",
           "max-license-ids": 6,
           "g3auto-name": "test-license-g3auto",
           "g3auto-key": "test_license.txt",

--- a/testData/testConfigMissingGSI.json
+++ b/testData/testConfigMissingGSI.json
@@ -1,0 +1,40 @@
+{
+    "user-namespace": "jupyter-pods",
+    "sub-dir": "/lw-workspace",
+    "user-volume-size": "10Gi",
+    "license-user-maps-dynamodb-table": "gen3-license-user-maps",
+    "sidecar": {
+      "cpu-limit": "1.0",
+      "memory-limit": "256Mi",
+      "image": "quay.io/cdis/gen3fuse-sidecar:chore_sidecar",
+      "env": {
+        "NAMESPACE": "default",
+        "HOSTNAME": "niaid.bionimbus.org"
+      },
+      "args": [],
+      "command": ["/bin/bash", "/sidecarDockerrun.sh"],
+      "lifecycle-pre-stop": ["su", "-c", "echo test", "-s", "/bin/sh", "root"]
+    },
+    "containers": [{
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "2Gi",
+        "name": "(Generic, Limited Gen3-licensed) Stata Notebook",
+        "image": "quay.io/cdis/jupyter-pystata-gen3-licensed:master",
+        "env": {
+          "FRAME_ANCESTORS": "https://dev.planx-pla.net"
+        },
+        "license": {
+          "enabled": true,
+          "license-type": "TEST-LICENSE",
+          "max-license-ids": 6,
+          "g3auto-name": "test-license-g3auto",
+          "g3auto-key": "test_license.txt",
+          "file-path": "licence-path.txt",
+          "workspace-flavor": "gen3-licensed"
+        },
+        "args": []
+      }
+
+    ]
+  }

--- a/testData/testConfigMissingLicenseTable.json
+++ b/testData/testConfigMissingLicenseTable.json
@@ -1,0 +1,39 @@
+{
+    "user-namespace": "jupyter-pods",
+    "sub-dir": "/lw-workspace",
+    "user-volume-size": "10Gi",
+    "sidecar": {
+      "cpu-limit": "1.0",
+      "memory-limit": "256Mi",
+      "image": "quay.io/cdis/gen3fuse-sidecar:chore_sidecar",
+      "env": {
+        "NAMESPACE": "default",
+        "HOSTNAME": "niaid.bionimbus.org"
+      },
+      "args": [],
+      "command": ["/bin/bash", "/sidecarDockerrun.sh"],
+      "lifecycle-pre-stop": ["su", "-c", "echo test", "-s", "/bin/sh", "root"]
+    },
+    "containers": [{
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "2Gi",
+        "name": "(Generic, Limited Gen3-licensed) Stata Notebook",
+        "image": "quay.io/cdis/jupyter-pystata-gen3-licensed:master",
+        "env": {
+          "FRAME_ANCESTORS": "https://dev.planx-pla.net"
+        },
+        "license": {
+          "enabled": true,
+          "license-type": "TEST-LICENSE",
+          "max-license-ids": 6,
+          "g3auto-name": "test-license-g3auto",
+          "g3auto-key": "test_license.txt",
+          "file-path": "licence-path.txt",
+          "workspace-flavor": "gen3-licensed"
+        },
+        "args": []
+      }
+
+    ]
+  }

--- a/testData/testConfigMissingLicenseTable.json
+++ b/testData/testConfigMissingLicenseTable.json
@@ -18,7 +18,7 @@
         "target-port": 8888,
         "cpu-limit": "1.0",
         "memory-limit": "2Gi",
-        "name": "(Generic, Limited Gen3-licensed) Stata Notebook",
+        "name": "Test-missing-license-table",
         "image": "quay.io/cdis/jupyter-pystata-gen3-licensed:master",
         "env": {
           "FRAME_ANCESTORS": "https://dev.planx-pla.net"


### PR DESCRIPTION
If your PayModel table is in another account then you would set up an access role in the other account. The ARN of the role can be specified in the hatchery config file. Hatchery will attempt to assume the role in the other account.

An example of a cross-account ARN is [here](https://github.com/uc-cdis/gitops-qa/blob/d0e575d4f271c05c93439d8fa5e0d18a2ffff69c/qa-heal.planx-pla.net/manifests/hatchery/hatchery.json#L11) 

JIRA ticket: [HP-1366](https://ctds-planx.atlassian.net/browse/HP-1366)

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
* Allow assume-role for cross-account access to pay model table

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[HP-1366]: https://ctds-planx.atlassian.net/browse/HP-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ