### PR TITLE
Make volumeHandle unique

### DIFF
--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -387,8 +387,8 @@ func userToResourceName(userName string, resourceType string) string {
 }
 
 func s3NamesForUser(userName string, namespace string) (pvName, pvcName, volumeHandle string) {
-	base := userToResourceName(userName, "s3")       // e.g. john-doe-s3
-	return base + "-" + namespace + "-pv", base + "-pvc", "s3-" + base // unique handle
+	base := userToResourceName(userName, "s3")                                   // e.g. john-doe-s3
+	return base + "-" + namespace + "-pv", base + "-pvc", base + "-" + namespace // unique handle
 }
 
 func s3PrefixForUser(userName string) string {


### PR DESCRIPTION
<!--
Starting a library workspace in one environment (say qa-brh) and then in a second environment (say qa-heal) caused stability issues and freezing the browser tab.

Stability seems to be improved by changing the volumeHandle to be unique.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

Make the volumeHandle unique

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
