### PR TITLE
Add support for hashed usernames in configuration and resource naming

### DIFF
--- a/doc/howto/configuration.md
+++ b/doc/howto/configuration.md
@@ -12,6 +12,7 @@ An example manifest entry may look like
     "user-namespace": "jupyter-pods",
     "sub-dir": "/lw-workspace",
     "user-volume-size": "10Gi",
+    "hashed-usernames": false,
     "use-internal-services-url": false
     "prisma": {
       "enable": true,
@@ -114,6 +115,8 @@ An example manifest entry may look like
 
 * `user-namespace` is which namespace the pods will be deployed into.
 * `sub-dir` is the path to Hatchery off the host domain, i.e. if the full domain path is `https://nci-crdc-demo.datacommons.io/lw-workspace` then `sub-dir` is `/lw-workspace`.
+* `hashed-usernames` if set to `true`, Hatchery hashes usernames before using them to generate Kubernetes resource names and related label/selector values, including pods, services, Ambassador mappings, and PVCs. This is useful when usernames may be too long or contain characters that are not safe for Kubernetes metadata, such as long OIDC `sub` values.
+  **Warning:** changing this setting changes the generated Kubernetes resource names for users. Existing PVCs created under the previous naming scheme will not be reused automatically. Enabling this setting will cause new PVCs to be created for users, so previous persistent workspace drives must be migrated manually if they need to be preserved.
 * `user-volume-size` the size of the user volume to be created. Applies to all containers because the user storage is the same across all of them.
 * `use-internal-services-url` Use internal service URLs (http://fence-service/ and http://ambassador-service/) for communication with other services instead of using GEN3_ENDPOINT environmental variable
 * `skip-node-selector` if set to `true`, will not set a node selector for the pods, which will be scheduled on any node. Useful for single-node clusters.

--- a/hatchery/config.go
+++ b/hatchery/config.go
@@ -135,6 +135,7 @@ type SharedWorkspaceConfig struct {
 type HatcheryConfig struct {
 	UserNamespace   string   `json:"user-namespace"`
 	DefaultPayModel PayModel `json:"default-pay-model"`
+	HashedUsernames bool     `json:"hashed-usernames"`
 	// DisableLocalWS         bool             `json:"disable-local-ws"`
 	SkipNodeSelector       bool                  `json:"skip-node-selector"`
 	UseInteralServicesURL  bool                  `json:"use-internal-services-url"`

--- a/hatchery/hatchery.go
+++ b/hatchery/hatchery.go
@@ -3,6 +3,8 @@ package hatchery
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -199,6 +201,15 @@ func timeTracker(w http.ResponseWriter, r *http.Request) {
 
 	// Important: Reset the body so it can be read again if needed
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
+}
+
+func hashUserName32(userName string) string {
+	sum := sha256.Sum256([]byte(userName))
+
+	// 16 bytes = 128 bits = 32 lowercase hex chars.
+	// Full SHA-256 hex is 64 chars and can still exceed k8s 63-char limits
+	// once prefixes/suffixes are added.
+	return hex.EncodeToString(sum[:16])
 }
 
 func getCurrentUserName(r *http.Request) (userName string) {

--- a/hatchery/pods.go
+++ b/hatchery/pods.go
@@ -336,6 +336,11 @@ var deleteK8sPod = func(ctx context.Context, userName string, accessToken string
 // and a resource type
 func userToResourceName(userName string, resourceType string) string {
 	safeUserName := escapism(userName)
+
+	if Config.Config.HashedUsernames {
+		safeUserName = hashUserName32(userName)
+	}
+
 	if resourceType == "pod" {
 		return fmt.Sprintf("hatchery-%s", safeUserName)
 	}


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/PD-147 

Addresses: https://github.com/uc-cdis/hatchery/issues/144

---

This PR adds support for generating Kubernetes-safe resource names from hashed usernames when `Config.Config.HashedUsername` is enabled.

When enabled, Hatchery hashes the incoming username and uses the hashed value when generating Kubernetes resources such as pods, services, mappings, and PVCs. This avoids failures caused by long or Kubernetes-incompatible usernames, for example OIDC `sub` values that exceed Kubernetes label or resource-name length limits after escaping.

The original username is still used for user identity and request/auth semantics where appropriate, but Kubernetes resource names are generated from the safe hashed username.

⚠️ **Migration warning:** enabling or disabling this setting changes the derived Kubernetes resource names for users. As a result, Hatchery will create new PVCs for users instead of reusing PVCs created under the previous naming scheme. Existing persistent workspace drives will not be automatically attached to the newly named resources and may appear to be lost unless migrated manually.

---

### New Features
- The new `hashed-usernames` setting adds support for generating Kubernetes-safe resource names from hashed usernames instead of plain usernames. This avoids failures caused by long or Kubernetes-incompatible usernames.

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
- Enabling the new `hashed-usernames` setting will cause existing persistent workspace drives to appear lost unless migrated manually to the new naming scheme.
